### PR TITLE
bin: working agentbrowser npx

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -117,7 +117,7 @@ export async function main() {
   );
 process.stdout.write(JSON.stringify(answer));
 await browser.close();
-return answer;
+return process.exit(0);
 }
 
 main()


### PR DESCRIPTION
While in the hdr-browser repo:

`npx . --agentProvider openai --agentModel gpt-4 --agentApiKey [key] --objective "how many editors are on wikipedia?" --startUrl "https://google.com"`

When deployed it will look more like:

`npx @hdr/browser --agentProvider openai --agentModel gpt-4 --agentApiKey [key] --objective "how many editors are on wikipedia?" --startUrl "https://google.com"`

if you start keeping env vars for rapid use you could do:

`npx @hdr/browser --objective "how many editors are on wikipedia?" --startUrl "https://google.com"`