### PR TITLE
package: fix type declaration resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "bin": {
     "nolita": "dist/bin/index.js"
   },
+  "types": "dist/types/index.d.ts",
   "keywords": [],
   "author": "HDR",
   "license": "MIT",


### PR DESCRIPTION
Right now when you import Nolita as a package it can't resolve the types for our classes. We need to tell it where to find our index.d.ts, now that we bundle it in the types folder (I believe this happened as part of #33).