### PR TITLE
use sane value names rather than random strings

### DIFF
--- a/src/inventory/index.ts
+++ b/src/inventory/index.ts
@@ -15,7 +15,7 @@ export class Inventory {
     this.maskedInventory = inventory.map((item) => {
       return {
         name: item.name,
-        value: this.maskValue(item.value, item.type),
+        value: `USER_PROVIDED_${item.name.toUpperCase()}`,
         type: item.type,
       };
     });
@@ -27,14 +27,6 @@ export class Inventory {
     });
 
     return inventoryArray.join(", ");
-  }
-
-  private maskValue(value: any, type: number | string) {
-    if (type === "string") {
-      return maskString(value);
-    } else if (type === "number") {
-      return maskNumber(value);
-    }
   }
 
   replaceMask(value: string): string {

--- a/src/inventory/index.ts
+++ b/src/inventory/index.ts
@@ -15,7 +15,7 @@ export class Inventory {
     this.maskedInventory = inventory.map((item) => {
       return {
         name: item.name,
-        value: `USER_PROVIDED_${item.name.toUpperCase()}`,
+        value: `USER_PROVIDED_${item.name.toUpperCase().replace(/ /g, "_")}`,
         type: item.type,
       };
     });

--- a/tests/inventory/index.test.ts
+++ b/tests/inventory/index.test.ts
@@ -9,9 +9,8 @@ describe("Inventory", () => {
     ];
     const inv = new Inventory(inventory);
     expect(inv.maskedInventory[0].value).not.toEqual("password");
-    expect(inv.maskedInventory[0].value.length).toEqual(8);
-    expect(inv.maskedInventory[1].value).toBeGreaterThanOrEqual(100);
-    expect(inv.maskedInventory[1].value).toBeLessThanOrEqual(999);
+    expect(inv.maskedInventory[0].value).toEqual("USER_PROVIDED_PASSWORD");
+    expect(inv.maskedInventory[1].value).toBe("USER_PROVIDED_AGE");
   });
 
   it("should replace mask", () => {


### PR DESCRIPTION
rather than using randomized strings, we use normalized values so we can do substitution more easily