### PR TITLE
build: deploy alpha builds to npm

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -42,6 +42,8 @@ jobs:
       
       - name: Publish alpha
         run: | 
+          git config --global user.name "Matilde Park"
+          git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           pnpm version prerelease --preid alpha.$git_hash
           pnpm publish --tag alpha

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -46,6 +46,6 @@ jobs:
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           pnpm version prerelease --preid alpha.$git_hash
-          pnpm publish --tag alpha
+          pnpm publish --tag alpha --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,6 +1,8 @@
 name: Push alpha artifact to npm
 on:
-  - push
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -45,6 +45,7 @@ jobs:
           git config --global user.name "Matilde Park"
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
           pnpm version prerelease --preid alpha.$git_hash
           pnpm publish --tag alpha --no-git-checks
         env:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,49 @@
+name: Push alpha artifact to npm
+on:
+  - push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Build
+        run: pnpm run build
+      
+      - name: Publish alpha
+        run: | 
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          pnpm version prerelease --preid alpha.$git_hash
+          pnpm publish --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
When a commit hits the main branch, we auto-build it and deploy it to the `alpha` tag on npm.

A user can then run it by hitting `npx nolita@alpha`.

Alpha versions look like this: `nolita@1.2.4-alpha.f748a02.0`

That is, it increments the version number a minor step, adds `-alpha-`, then adds the git hash and `.0`.

Fixes #47 