### PR TITLE
build: don't tag prerelease versions

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
-          pnpm version prerelease --preid alpha.$git_hash
+          pnpm version prerelease --preid alpha.$git_hash --no-git-tag-version
           pnpm publish --tag alpha --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Should fix "Git working directory not being clean".