### PR TITLE
create: remove LICENSE when scaffolding

### DIFF
--- a/src/bin/commands/create.ts
+++ b/src/bin/commands/create.ts
@@ -30,6 +30,7 @@ module.exports = {
             maxConcurrentProcesses: 6,
         }).clone('git@github.com:hdresearch/create.git', name)
         filesystem.remove(`${name}/.git`)
+        filesystem.remove(`${name}/LICENSE`)
         filesystem.move(`${name}/extensions/.inventory.example`, `${name}/extensions/.inventory`)
         toolbox.print.success(`Created ${name} project`)
         toolbox.system.run(`cd ${name} && npm install`)


### PR DESCRIPTION
We retain hdresearch/create's MIT license by HDR when creating new projects. It should be removed.