### PR TITLE
bin: add auth command, help command, hdrDisable flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "llm-api": "^1.2.0",
     "lodash": "^4.17.21",
     "openai": "^4.28.0",
+    "out-url": "^1.2.2",
     "puppeteer": "^22.0.0",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   openai:
     specifier: ^4.28.0
     version: 4.32.1
+  out-url:
+    specifier: ^1.2.2
+    version: 1.2.2
   puppeteer:
     specifier: ^22.0.0
     version: 22.6.2(typescript@5.4.3)
@@ -4506,6 +4509,10 @@ packages:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /out-url@1.2.2:
+    resolution: {integrity: sha512-9YX6NkfE8kujbeK0h1m+z8AdVYN3luHeF55ayNKks1qIfpsNInwQa4F5WAbSHhxEQvPDEB7tSnbK3RIvCxjJoA==}
+    dev: false
 
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}

--- a/src/bin/commands/auth.ts
+++ b/src/bin/commands/auth.ts
@@ -1,0 +1,66 @@
+import { GluegunToolbox } from "gluegun";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+const { open } = require('out-url');
+
+
+const loadConfigFile = (filePath: string): any => {
+    try {
+      return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (error) {
+      return {};
+    }
+  };
+
+  const writeToNolitarc = (key: string, value: string): void => {
+    const nolitarcPath = path.resolve(os.homedir(), ".nolitarc");
+    let nolitarc = {};
+    try {
+      const nolitarcContent = fs.readFileSync(nolitarcPath, "utf8");
+      nolitarc = JSON.parse(nolitarcContent);
+    } catch (error) {
+      // File does not exist or is not valid JSON
+    }
+    nolitarc = { ...nolitarc, [key]: value };
+    fs.writeFileSync(nolitarcPath, JSON.stringify(nolitarc));
+  };
+
+  export const run = async (toolbox: GluegunToolbox) => {
+
+    const homeConfig = loadConfigFile(path.resolve(os.homedir(), ".nolitarc"));
+    const { hdrApiKey } = homeConfig;
+    const { print, prompt } = toolbox;
+    if (!hdrApiKey) {
+        print.error("No HDR API key found in ~/.nolitarc.");
+        await prompt.ask({
+            type: "confirm",
+            name: "create",
+            message: "Would you like to sign up at dashboard.hdr.is?",
+        }).then(async ({ create }) => {
+            if (create) {
+                open("https://dashboard.hdr.is");
+            }
+        });
+        const { apiKey } = await prompt.ask({
+            type: "input",
+            name: "apiKey",
+            message: "Please access https://dashboard.hdr.is/keys and enter your generated HDR API key.",
+        });
+        writeToNolitarc("hdrApiKey", apiKey);
+    }
+
+    if (hdrApiKey) {
+        print.success("HDR API key found in ~/.nolitarc.");
+        await prompt.ask({
+            type: "confirm",
+            name: "delete",
+            message: "Delete HDR API key?",
+        }).then(({ delete: del }) => {
+            if (del) {
+                writeToNolitarc("hdrApiKey", "");
+                print.success("HDR API key deleted.");
+            }
+        })
+    }
+  }

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -4,9 +4,10 @@ import { build } from "gluegun";
 import { run } from "./run";
 
 const cli = build()
-  .brand("hdr")
+  .brand("nolita")
   .src(__dirname)
   .plugins("./node_modules", { matching: "hdr-*", hidden: true })
+  .help()
   .defaultCommand(run)
   .create()
   .run()

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -42,6 +42,7 @@ export class Browser {
    * @param {string} [opts.endpoint] - The HDR collective memory endpoint.
    * @param {Inventory} [opts.inventory] - The inventory to use for the browser.
    * @param {BrowserMode} [opts.mode=BrowserMode.text] - The mode of the browser (e.g., text).
+   * @param {boolean} [opts.disableMemory=false] - Specifies if the browser should disable memory.
    */
   constructor(
     browser: PuppeteerBrowser,
@@ -78,6 +79,8 @@ export class Browser {
    * @param {BrowserMode} [opts.mode=BrowserMode.text] - The mode of the browser, defaults to text.
    * @param {string} [opts.apiKey] - The API key for the browser.
    * @param {string} [opts.endpoint] - The HDR collective memory endpoint.
+   * @param {Inventory} [opts.inventory] - The inventory to use for the browser.
+   * @param {boolean} [opts.disableMemory=false] - Specifies if the browser should disable memory.
    * @returns {Promise<Browser>} A promise that resolves to an instance of Browser.
    */
   static async launch(
@@ -91,6 +94,7 @@ export class Browser {
       apiKey?: string;
       endpoint?: string;
       inventory?: Inventory;
+      disableMemory?: boolean;
     }
   ): Promise<Browser> {
     const browser = new Browser(


### PR DESCRIPTION
- We didn't seem to allow `disableMemory` in `Browser.launch()`, so I added that. We were also missing some documentation for it.
  - I did find that `opts.disableMemory` was `true` when passing `--hdrDisable` but not clear if that persists inside `AgentBrowser`, which appears to still hardcode memory stuff.
  - In general, I believe that it should be all or nothing: read-only memory index use shouldn't be possible in basic Nolita. So if you disable using memories you should disable writing memories at the same time.
- Adds a `help` command with our commands, version, etc.
- If we don't have a key we tell the user to use `npx nolita auth`, unless `hdrDisable` flag is passed, then we suppress the warning.
- `npx nolita auth` pushes user to the dashboard, where they sign in with magic link (see PR in dash repo) and then procure a key, entering it in here.
- `hdrApiKey` flags and env variables still work but we should basically discourage it in docs now. The auth flow is easier and compartmentalises it.