### PR TITLE
Ty/record remember

### DIFF
--- a/examples/followRoute.ts
+++ b/examples/followRoute.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+import { Browser } from "../src/browser";
+import { makeAgent } from "../src/agent";
+import { Logger } from "../src/utils";
+
+async function makeRoute(browser: Browser, schema: z.ZodObject<any>) {
+  const page = await browser.newPage();
+  await page.goto("https://hdr.is");
+  await page.do("click on the company link");
+  const answer = await page.get(
+    "Find all the email addresses on the page",
+    schema
+  );
+
+  console.log(answer);
+  return page.pageId;
+}
+
+async function followRoute(
+  browser: Browser,
+  routeId: string,
+  schema: z.ZodObject<any>
+) {
+  const page = await browser.newPage();
+
+  await page.followRoute(routeId, { schema });
+}
+
+async function main() {
+  const agent = makeAgent(
+    { provider: "openai", apiKey: process.env.OPENAI_API_KEY! },
+    { model: "gpt-4" }
+  );
+  const logger = new Logger(["info"], (msg) => console.log(msg));
+  const browser = await Browser.launch(false, agent, logger);
+
+  const emailSchema = z.object({
+    emails: z
+      .array(z.string())
+      .describe("The email addresses found on the page"),
+  });
+  const routeId = await makeRoute(browser, emailSchema);
+
+  await followRoute(browser, routeId, emailSchema);
+
+  await browser.close();
+}
+
+main();

--- a/examples/followRoute.ts
+++ b/examples/followRoute.ts
@@ -24,7 +24,8 @@ async function followRoute(
 ) {
   const page = await browser.newPage();
 
-  await page.followRoute(routeId, { schema });
+  const answer = await page.followRoute(routeId, { schema });
+  console.log(answer);
 }
 
 async function main() {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -661,16 +661,6 @@ export class Page {
     }
   }
 
-  async modifyCommands(memory: Memory, state: ObjectiveState) {
-    // const state = await this.state(
-    //   memory.objectiveState.objective,
-    //   this.progress
-    // );
-
-    const { actionStep, objectiveState } = Memory.parse(memory);
-    const ff = updateCommandIndices(objectiveState, state, actionStep.command);
-  }
-
   /**
    * Follows a route based on a memory sequence.
    * @param {string} memoryId The memory sequence ID.
@@ -701,11 +691,12 @@ export class Page {
     if (memories.length === 0) {
       throw new Error(`No memories found for memory sequence id ${memoryId}`);
     }
-    console.log(JSON.stringify(memories));
 
     for (const memory of memories) {
       await this.performMemory(memory, opts);
     }
+
+    this.log(`Route finishef for memory sequence id: ${memoryId}`);
   }
 
   /**

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -705,10 +705,13 @@ export class Page {
     }
 
     for (const memory of memories) {
-      await this.performMemory(memory, opts);
+      const result = await this.performMemory(memory, opts);
+      if (result) {
+        return result;
+      }
     }
 
-    this.log(`Route finishef for memory sequence id: ${memoryId}`);
+    this.log(`Route finished for memory sequence id: ${memoryId}`);
   }
 
   /**

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -260,7 +260,7 @@ export class Page {
 
     const ret = (await this.page
       .mainFrame()
-      // this is black magic referred to the execution context
+      // this is black magic referring to the execution context
       // @ts-ignore
       .worlds[MAIN_WORLD].adoptBackendNode(
         backendNodeId

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -197,8 +197,8 @@ export class Page {
       const state: ObjectiveState = {
         kind: "ObjectiveState",
         objective: "navigate to " + url,
-        url: url,
-        ariaTree: "about:blank",
+        url: this.url(),
+        ariaTree: "[]",
         progress: [],
       };
       const action: ModelResponseType = {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -376,7 +376,6 @@ export class Page {
           break;
         case "Type":
           let text = command.text;
-
           // repalce masked inventory values with real values
           if (inventory) {
             text = inventory.replaceMask(text);

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -550,6 +550,18 @@ export class Page {
     const result = await agent.returnCall(prompt, outputSchema);
 
     this.log(JSON.stringify(result));
+
+    if (!this.disableMemory) {
+      const action: ModelResponseType = {
+        command: [{ kind: "Get", type: "aria", request }],
+        description: "Getting data from the page",
+        progressAssessment: "",
+      };
+      await memorize(this._state!, action as ModelResponseType, this.pageId, {
+        endpoint: process.env.HDR_API_ENDPOINT ?? "https://api.hdr.is",
+        apiKey: process.env.HDR_API_KEY ?? "",
+      });
+    }
     return result;
   }
 

--- a/src/collectiveMemory/memorize.ts
+++ b/src/collectiveMemory/memorize.ts
@@ -9,12 +9,16 @@ export async function memorize(
   sequenceId: string,
   collectiveMemoryConfig?: CollectiveMemoryConfig
 ) {
-  const config = CollectiveMemoryConfig.parse(collectiveMemoryConfig);
-  const endpoint = `${config.endpoint}/memorize`;
+  const endpointValue =
+    process.env.HDR_ENDPOINT! ??
+    collectiveMemoryConfig?.endpoint ??
+    "https://api.hdr.is";
 
+  const apiKey = collectiveMemoryConfig?.apiKey ?? process.env.HDR_API_KEY;
+  const endpoint = `${endpointValue}/memorize`;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
   };
 
   const resp = await fetch(endpoint, {

--- a/src/collectiveMemory/memorize.ts
+++ b/src/collectiveMemory/memorize.ts
@@ -6,7 +6,7 @@ import { debug } from "../utils";
 export async function memorize(
   state: ObjectiveState,
   action: ModelResponseType,
-  sequnceId: string,
+  sequenceId: string,
   collectiveMemoryConfig?: CollectiveMemoryConfig
 ) {
   const config = CollectiveMemoryConfig.parse(collectiveMemoryConfig);
@@ -21,7 +21,7 @@ export async function memorize(
     method: "POST",
     headers,
     body: JSON.stringify({
-      sequence_id: sequnceId,
+      sequence_id: sequenceId,
       memory: {
         state,
         action,

--- a/src/types/browser/actions.types.ts
+++ b/src/types/browser/actions.types.ts
@@ -38,6 +38,11 @@ const Scroll = z.object({
   direction: z.enum(["up", "down"]).describe("The direction to scroll"),
 });
 
+const GoTo = z.object({
+  kind: z.literal("GoTo").describe("Go to a specific URL"),
+  url: z.string().url().describe("The URL to navigate to"),
+});
+
 export const BrowserAction = z.union([
   Type,
   Click,
@@ -46,6 +51,7 @@ export const BrowserAction = z.union([
   Enter,
   Hover,
   Scroll,
+  GoTo,
 ]);
 
 export type BrowserAction = z.infer<typeof BrowserAction>;

--- a/src/types/browser/actions.types.ts
+++ b/src/types/browser/actions.types.ts
@@ -43,6 +43,15 @@ const GoTo = z.object({
   url: z.string().url().describe("The URL to navigate to"),
 });
 
+const Get = z.object({
+  kind: z.literal("Get").describe("Get information from the page"),
+  request: z.string().describe("The request to get from the page"),
+  type: z
+    .enum(["html", "aria", "markdown", "text", "image"])
+    .default("aria")
+    .describe("The format inspect the page"),
+});
+
 export const BrowserAction = z.union([
   Type,
   Click,
@@ -52,6 +61,7 @@ export const BrowserAction = z.union([
   Hover,
   Scroll,
   GoTo,
+  Get,
 ]);
 
 export type BrowserAction = z.infer<typeof BrowserAction>;

--- a/src/types/collectiveMemory/config.types.ts
+++ b/src/types/collectiveMemory/config.types.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 export const CollectiveMemoryConfig = z.object({
-  endpoint: z.string().url().default("https://api.hdr.is"),
+  endpoint: z
+    .string()
+    .url()
+    .default(process.env.HDR_ENDPOINT ?? "https://api.hdr.is"),
   apiKey: z
     .string()
     .optional()

--- a/src/types/memory.types.ts
+++ b/src/types/memory.types.ts
@@ -2,9 +2,10 @@ import { z } from "zod";
 
 import { ModelResponseSchema } from "./browser/actionStep.types";
 import { ObjectiveState } from "./browser/browser.types";
+import { BrowserActionArray } from "./browser/actions.types";
 
 export const Memory = z.object({
-  actionStep: ModelResponseSchema(),
+  actionStep: ModelResponseSchema(undefined, BrowserActionArray),
   objectiveState: ObjectiveState,
 });
 


### PR DESCRIPTION
Simple replay abiliity

Adds new methods to `page` that allow users to replay actions. We also added two new `BrowserActions` to the mix. The `GoTo` and `Get` actions have been added so we can do programmatic replay for `page.goto` and `page.get`. However we do not expose these new action types to the agent class. Instead they are handled by the `page` object. In the future we may expose `GoTo` to the agent class but that degree of flexibility kind of freaks me out. 