### PR TITLE
agent, browser: nolitarc integration

### DIFF
--- a/examples/findEmail.ts
+++ b/examples/findEmail.ts
@@ -3,6 +3,11 @@ import { makeAgent } from "../src/agent/index.ts";
 import { z } from "zod";
 
 async function main() {
+  // If you run npx nolita auth, and save your keys during any `npx nolita` session,
+  // you can simply use the following instead:
+  // 
+  // const agent = makeAgent();
+  // 
   const agent = makeAgent(
     { apiKey: process.env.OPENAI_API_KEY!, provider: "openai" },
     { model: "gpt-4" }

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -14,6 +14,8 @@ import { Inventory } from "../inventory";
 import { ObjectiveComplete } from "../types/browser/objectiveComplete.types";
 import { generateSchema, SchemaElement } from "./schemaGenerators";
 import { debug } from "../utils";
+import { completionApiBuilder } from "./config";
+import { nolitarc } from "../utils/config";
 
 export function stringifyObjects<T>(obj: T[]): string {
   const strings = obj.map((o) => JSON.stringify(o));
@@ -24,8 +26,20 @@ export class Agent {
   private modelApi: CompletionApi;
   systemPrompt?: string;
 
-  constructor(agentArgs: { modelApi: CompletionApi; systemPrompt?: string }) {
-    this.modelApi = agentArgs.modelApi;
+  constructor(agentArgs: { modelApi?: CompletionApi; systemPrompt?: string }) {
+    if (agentArgs.modelApi) {
+      this.modelApi = agentArgs.modelApi;
+    } else {
+      try {
+        const { agentApiKey, agentProvider, agentModel } = nolitarc();
+        this.modelApi = completionApiBuilder(
+          { provider: agentProvider, apiKey: agentApiKey },
+          { model: agentModel }
+        ) as CompletionApi;
+      } catch (error) {
+        throw new Error("Failed to create chat api");
+      }
+    }
     this.systemPrompt = agentArgs.systemPrompt;
   }
 

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -5,6 +5,7 @@ import {
   ModelConfig,
 } from "llm-api";
 import { Agent } from "./agent";
+import { nolitarc } from "../utils/config";
 
 export const CompletionDefaultRetries = 3;
 export const CompletionDefaultTimeout = 300_000;
@@ -40,11 +41,22 @@ export function completionApiBuilder(
 }
 
 export function makeAgent(
-  prodiverOpts: { provider: string; apiKey: string },
-  modelConfig: ModelConfig,
+  prodiverOpts?: { provider: string; apiKey: string },
+  modelConfig?: ModelConfig,
   customProvider?: CompletionApi,
   opts?: { systemPrompt?: string }
 ) {
+  if (!prodiverOpts) {
+    const { agentApiKey, agentProvider, agentModel } = nolitarc();
+    prodiverOpts = { provider: agentProvider, apiKey: agentApiKey };
+    modelConfig = { model: agentModel };
+  }
+  if (!prodiverOpts.provider) {
+    throw new Error("Provider is required");
+  }
+  if (!modelConfig?.model) {
+    throw new Error("Model is required");
+  }
   const chatApi = completionApiBuilder(
     prodiverOpts,
     modelConfig,

--- a/src/bin/run.ts
+++ b/src/bin/run.ts
@@ -35,7 +35,6 @@ const getConfig = (
   agentProvider: string | undefined,
   agentModel: string | undefined,
   agentApiKey: string | undefined,
-  agentEndpoint: string | undefined,
   hdrApiKey: string | undefined,
   headless: boolean | string | undefined,
   hdrDisable: boolean | string | undefined
@@ -50,10 +49,6 @@ const getConfig = (
     agentModel || mergedConfig.agentModel || process.env.HDR_AGENT_MODEL,
   agentApiKey:
     agentApiKey || mergedConfig.agentApiKey || process.env.HDR_AGENT_API_KEY,
-  agentEndpoint:
-    agentEndpoint ||
-    mergedConfig.agentEndpoint ||
-    process.env.HDR_AGENT_ENDPOINT,
   hdrApiKey: hdrApiKey || mergedConfig.hdrApiKey || process.env.HDR_API_KEY,
   headless: headless ?? mergedConfig.headless ?? process.env.HDR_HEADLESS,
   hdrDisable: hdrDisable ?? mergedConfig.hdrDisable ?? process.env.HDR_DISABLE,
@@ -80,7 +75,6 @@ export const run = async (toolbox: GluegunToolbox) => {
     agentProvider,
     agentModel,
     agentApiKey,
-    agentEndpoint,
     hdrApiKey,
     headless,
     config,
@@ -95,7 +89,6 @@ export const run = async (toolbox: GluegunToolbox) => {
     agentProvider,
     agentModel,
     agentApiKey,
-    agentEndpoint,
     hdrApiKey,
     headless,
     hdrDisable
@@ -227,7 +220,6 @@ export const run = async (toolbox: GluegunToolbox) => {
   const providerOptions = {
     apiKey: resolvedConfig.agentApiKey!,
     provider: resolvedConfig.agentProvider,
-    endpoint: resolvedConfig.agentEndpoint,
   };
   const chatApi = completionApiBuilder(providerOptions, {
     model: resolvedConfig.agentModel,

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -6,6 +6,7 @@ import { browserContext } from "./browserUtils";
 import { Agent } from "../agent";
 import { Logger } from "../utils";
 import { Inventory } from "../inventory";
+import { nolitarc } from "../utils/config";
 
 /**
  * Represents a browser session using Puppeteer.
@@ -56,7 +57,9 @@ export class Browser {
       disableMemory?: boolean;
     }
   ) {
-    this.apiKey = opts?.apiKey || process.env.HDR_API_KEY;
+    const { hdrApiKey } = nolitarc();
+    this.disableMemory = opts?.disableMemory || false;
+    this.apiKey = opts?.apiKey || hdrApiKey || process.env.HDR_API_KEY;
     this.endpoint = opts?.endpoint || process.env.HDR_ENDPOINT;
 
     this.agent = agent;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,21 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const loadConfigFile = (filePath: string): any => {
+    try {
+      return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (error) {
+      return {};
+    }
+  };
+  
+export const nolitarc = () => {
+    try {
+        const homeConfig = loadConfigFile(path.resolve(os.homedir(), ".nolitarc"));
+        return homeConfig;
+    }
+    catch {
+        return {};
+    }
+}


### PR DESCRIPTION
`.nolitarc` stores user config across `npx nolita` sessions and includes `npx nolita auth` details as well, meaning if you use either, you invariably have:

```json
{
  "hdrApiKey": "...",
  "agentModel": "...",
  "agentProvider": "..."
  "agentApiKey": "..."
}
```

Already set. This is only available in the task runner, though.

This PR integrates that across Nolita, and makes all parameters therefore optional. If no parameters are provided and the nolitarc check fails, we throw during any constructor call.

The ideal case I'm trying to facilitate here is that if you've run `npx nolita` and `npx nolita auth`, then in any Nolita project on a machine, you can just run:

```ts
const agent = makeAgent();
const browser = Browser.launch(false, agent);
const page = browser.newPage();
...
```

Without ever having to think about keys or declaring process.env variables.