### PR TITLE
bin: use nolitarc for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ npx nolita serve
 
 ![](https://content.hdr.is/serve.gif)
 
-Runs a local API for objective-first agentic navigation of a local Chrome instance. After starting the server, you can see the `/doc` folder for the expected JSON payload.
+Runs a local API for objective-first agentic navigation of a local Chrome instance. 
+
+The server is set up with all keys first initialized with `npx nolita auth`. After starting the server, you can see the `/doc` folder for the expected JSON payload.
 
 Use `--port` to customize the port.
 

--- a/src/server/browser/launch.ts
+++ b/src/server/browser/launch.ts
@@ -76,7 +76,7 @@ launchRouter.openapi(route, async (c) => {
     launchArgs,
     headless,
   } = c.req.valid("json");
-  const { agentApiKey, agentProvider, agentModel } = nolitarc();
+  const { agentApiKey, agentProvider, agentModel, hdrApiKey } = nolitarc();
   if (!agentProvider) {
     return c.json(
       {
@@ -106,6 +106,7 @@ launchRouter.openapi(route, async (c) => {
     mode,
     browserWSEndpoint: wsEndpoint,
     browserLaunchArgs: launchArgs,
+    ...(hdrApiKey && {apiKey: hdrApiKey}),
   });
 
   const sessionId = generateUUID();

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -10,19 +10,6 @@ export const browseSchema = z.object({
   maxIterations: z.number().int().default(20).openapi({ example: 10 }),
 });
 
-export const providerSchema = z.object({
-  provider: z.string().openapi({ example: "openai" }),
-  apiKey: z
-    .string()
-    .default(process.env.OPENAI_API_KEY!)
-    .openapi({ example: "your-api-key" }),
-});
-
-export const modelSchema = z.object({
-  model: z.string().openapi({ example: "gpt-4" }),
-  temperature: z.number().optional().openapi({ example: 0 }),
-});
-
 export const InventorySchema = z.array(
   z.object({
     name: z.string().openapi({ example: "Username" }),
@@ -55,8 +42,6 @@ export const jsonSchema: z.ZodType<Json> = z
 export const apiSchema = z
   .object({
     browse_config: browseSchema,
-    provider_config: providerSchema,
-    model_config: modelSchema,
     response_type: z
       .any()
       .optional()


### PR DESCRIPTION
You shouldn't need to pass keys on the client side SDK every single time. Since Nolita is running on-device, it should just pull from `nolita auth`. This replaces all agent and HDR parameters with calls to `nolitarc`.

We also didn't have HDR integration in the browser endpoint, so I've added that.

I wish I knew how to not require any JSON at all, though. It looks like this now:

```sh
maru@keina ~> curl -X POST http://localhost:3000/browser/session/launch -H "Content-Type: application/json" --data "{}"
{"sessionId":"42a2b9c2-34b8-46ca-ad06-cf30c2f50527"}%  
```