### PR TITLE
bin/create: use https url

### DIFF
--- a/src/bin/commands/create.ts
+++ b/src/bin/commands/create.ts
@@ -29,7 +29,7 @@ module.exports = {
       baseDir: process.cwd(),
       binary: "git",
       maxConcurrentProcesses: 6,
-    }).clone("git@github.com:hdresearch/create.git", name);
+    }).clone("https://github.com/hdresearch/create.git", name);
     filesystem.remove(`${name}/.git`);
     filesystem.remove(`${name}/LICENSE`);
     filesystem.move(


### PR DESCRIPTION
We were using the GitHub SSH URL, which enforced that users of the `create` command have a GitHub account with SSH verification already set up, even though it's a public repository.