### PR TITLE
browserUtils: check for chromepath

### DIFF
--- a/src/browser/browserUtils.ts
+++ b/src/browser/browserUtils.ts
@@ -1,6 +1,7 @@
 import * as chromePaths from "chrome-paths";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
 import puppeteer from "puppeteer-extra";
+import fs from "fs";
 
 import { Browser as PuppeteerBrowser } from "puppeteer";
 import { BROWSER_LAUNCH_ARGS } from "./browserDefaults";
@@ -19,6 +20,9 @@ export const getChromePath = (): string | undefined => {
     chromePath = process.env.CHROME_PATH;
   } else {
     chromePath = chromePaths.chrome;
+  }
+  if (chromePath === undefined || !fs.existsSync(chromePath)) {
+    return undefined;
   }
   return chromePath;
 };


### PR DESCRIPTION
We actually see if ChromePath is there before passing it to Puppeteer (which falls back to its own installation).

I think that in Linux cases, if you have `google-chrome-stable` installed then it causes some sort of clobber case. chrome-paths [outsources its logic to another package](https://github.com/shinnn/chrome-paths/blob/master/index.js) (lol) which tries to run it in [context](https://github.com/karma-runner/karma-chrome-launcher/blob/master/index.js#L125) which then isn't available to our Puppeteer context. Why? I don't know, really, it comes down to what user a command runs as. If we just passed `/usr/bin/google-chrome` it would work. Instead we pass `google-chrome` and it crashes once Puppeteer gets that path.

What I inadvertently learned is that because we use `chrome-paths` we also support Chromium and Canary, since that's what Karma Chrome Launcher looks for.