### PR TITLE
examples: update all, amend config prompting

### DIFF
--- a/examples/shopping.ts
+++ b/examples/shopping.ts
@@ -1,14 +1,17 @@
 import yargs from "yargs/yargs";
 import { z } from "zod";
 
-import { AgentBrowser } from "../src/agentBrowser";
 import { Browser } from "../src/browser";
 import { Agent } from "../src/agent/agent";
 import { Inventory } from "../src/inventory";
 import { completionApiBuilder } from "../src/agent";
 import { Logger } from "../src/utils";
+import { nolitarc } from "../src/utils/config";
 
-import { ModelResponseSchema, ObjectiveComplete } from "../src/types";
+// these are imported from `npx nolita auth`
+// if you haven't set config, you can set the defaults for this example in your environment:
+// OPENAI_API_KEY, HDR_API_KEY
+const { hdrApiKey, agentProvider, agentModel, agentApiKey } = nolitarc();
 
 const parser = yargs(process.argv.slice(2)).options({
   headless: { type: "boolean", default: true },
@@ -24,10 +27,10 @@ async function main() {
   const maxIterations = 15;
 
   const providerOptions = {
-    apiKey: process.env.OPENAI_API_KEY!,
-    provider: "openai",
+    apiKey: agentApiKey || process.env.OPENAI_API_KEY!,
+    provider: agentProvider || "openai",
   };
-  const chatApi = completionApiBuilder(providerOptions, { model: "gpt-4" });
+  const chatApi = completionApiBuilder(providerOptions, { model: agentModel || "gpt-4" });
 
   if (!chatApi) {
     throw new Error(
@@ -36,40 +39,25 @@ async function main() {
   }
   const logger = new Logger(["info"], (msg) => console.log(msg));
 
-  // You can pass in collective memory configuration to the agent browser
-  const collectiveMemoryConfig = {
-    apiKey: process.env.HDR_API_KEY!,
-    endpoint: process.env.HDR_ENDPOINT!,
-  };
   const agent = new Agent({ modelApi: chatApi });
-  const agentBrowser = new AgentBrowser({
-    agent: new Agent({ modelApi: chatApi }),
-    browser: await Browser.launch(argv.headless, agent),
-    logger,
+  const browser = await Browser.launch(argv.headless, agent, logger, {
+    apiKey: hdrApiKey || process.env.HDR_API_KEY!,
+  });
+  const page = await browser.newPage();
+  await page.goto(startUrl);
+  const answer = await page.browse(objective, {
+    maxTurns: maxIterations,
+    schema: z.object({
+      orderTotals: z.array(z.number()).describe("The order total in number format"),
+    }),
     inventory: new Inventory([
       { value: "emma.lopez@gmail.com", name: "email", type: "string" },
       { value: "Password.123", name: "Password", type: "string" },
     ]),
-    collectiveMemoryConfig,
   });
-
-  const orderTotalAnswer = ObjectiveComplete.extend({
-    orderTotals: z.array(
-      z.number().describe("The order total in number format")
-    ),
-  });
-
-  const answer = await agentBrowser.browse(
-    {
-      startUrl: startUrl,
-      objective: [objective],
-      maxIterations: maxIterations,
-    },
-    ModelResponseSchema(orderTotalAnswer)
-  );
-
-  console.log("\x1b[32m Answer:", JSON.stringify(answer?.result));
-  await agentBrowser.close();
+  // @ts-expect-error - we are not using the full response schema
+  console.log("\x1b[32m Answer:", JSON.stringify(answer?.objectiveComplete?.orderTotals));
+  await browser.close();
 }
 
 main();

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
   verbose: true,
   preset: "ts-jest",
   testEnvironment: "node",
+  testTimeout: 20000
 };
 
 export default config;

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -67,7 +67,9 @@ export class Agent {
     memories: Memory[],
     config?: { inventory?: Inventory; systemPrompt?: string }
   ): ChatRequestMessage[] {
-    const userPrompt = `Here are examples of a request: 
+    const userPrompt = `
+    ${config?.inventory ? `Use the following information to achieve your objective as needed: ${config?.inventory.toString()}` : ""}
+    Here are examples of a request: 
     ${stringifyObjects(memories)}
 
     remember to return a result only in the form of an ActionStep.

--- a/src/agent/messages.ts
+++ b/src/agent/messages.ts
@@ -77,20 +77,13 @@ export function handleConfigMessages(
 ): ChatRequestMessage[] {
   const messages: ChatRequestMessage[] = [];
 
-  const { systemPrompt, inventory } = config;
+  const { systemPrompt } = config;
 
   if (systemPrompt) {
     console.log("systemPrompt", systemPrompt);
     messages.push({
       role: "system",
       content: systemPrompt,
-    });
-  }
-
-  if (inventory) {
-    messages.push({
-      role: "user",
-      content: `Use the following information to achieve your objective as needed: ${inventory.toString()}`,
     });
   }
 

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -638,7 +638,10 @@ export class Page {
   ) {
     let currentTurn = 0;
     while (currentTurn < opts.maxTurns) {
-      const step = await this.step(objective, opts?.schema, opts);
+      const step = await this.step(objective, opts?.schema, {
+        ...opts,
+        inventory: opts.inventory ?? this.inventory,
+      });
 
       if (step?.objectiveComplete) {
         return step;

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -32,20 +32,6 @@ describe("Agent -- configs", () => {
     agent = new Agent({ modelApi: chatApi! });
   });
 
-  test("that configs are handled", async () => {
-    const prompt = await agent.prompt(
-      stateActionPair1.objectiveState,
-      [stateActionPair1],
-      {
-        inventory: new Inventory([
-          { value: "test", name: "test", type: "string" },
-        ]),
-      }
-    );
-    expect(prompt[0].role).toBe("user");
-    expect(prompt[0].content).toContain("Use the following information");
-  });
-
   test("that empty configs are handled", async () => {
     const prompt = await agent.prompt(
       stateActionPair1.objectiveState,

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -10,8 +10,6 @@ import {
   ObjectiveComplete,
 } from "../../src/types/browser/actionStep.types";
 
-import { Inventory } from "../../src/inventory";
-
 import { z } from "zod";
 import { ObjectiveState } from "../../src/types/browser";
 import { completionApiBuilder } from "../../src/agent/config";

--- a/tests/agent/messages.test.ts
+++ b/tests/agent/messages.test.ts
@@ -15,16 +15,6 @@ describe("handleConfigMessages", () => {
     expect(messages[0].content).toBe("test");
   });
 
-  it("should return an inventory message", () => {
-    const messages = handleConfigMessages({
-      inventory: new Inventory([
-        { value: "test", name: "test", type: "string" },
-      ]),
-    });
-    expect(messages[0].role).toBe("user");
-    expect(messages[0].content).toContain("Use the following information");
-  });
-
   it("should return both messages", () => {
     const messages = handleConfigMessages({
       systemPrompt: "test",
@@ -34,8 +24,6 @@ describe("handleConfigMessages", () => {
     });
     expect(messages[0].role).toBe("system");
     expect(messages[0].content).toBe("test");
-    expect(messages[1].role).toBe("user");
-    expect(messages[1].content).toContain("Use the following information");
   });
 });
 
@@ -62,17 +50,12 @@ describe("CommandPrompt", () => {
       }
     );
 
-    expect(messages[0].role).toBe("user");
-    expect(messages[0].content).toContain(
-      "Use the following information to achieve your objective as needed"
-    );
-
-    expect(messages[2].role).toBe("user");
-    expect(messages[2].content).toContain(
+    expect(messages[1].role).toBe("user");
+    expect(messages[1].content).toContain(
       "Please generate the next ActionStep for"
     );
 
-    expect(messages.length).toBe(3);
+    expect(messages.length).toBe(2);
   });
 
   it("should return a command prompt with a system prompt", () => {
@@ -147,15 +130,10 @@ describe("getPrompt", () => {
 
     expect(messages[0].role).toBe("user");
     expect(messages[0].content).toContain(
-      "Use the following information to achieve your objective as needed"
-    );
-
-    expect(messages[1].role).toBe("user");
-    expect(messages[1].content).toContain(
       "Here is the current aria of the page"
     );
 
-    expect(messages.length).toBe(2);
+    expect(messages.length).toBe(1);
   });
 
   it("should return a get prompt with a system prompt", () => {


### PR DESCRIPTION
Rewrites all examples to use the page API and nolitarc.

Incidentally noticed two things while rewriting:
- ~passing inventory to the browser acted as if no inventory was passed at all;~

~Try it out on shopping.ts in this branch. If you move the inventory from the page.browse() call and into browser.launch, and run it with headless set to false, it types in random details trying to guess at a username and password~

I fixed it in e2f014ff457273fe123a9bf23f10f75de3596507

- if I *did* move the inventory to the page.browse call, Anthropic SDK crashes because it cannot have two user messages in a row

I got around this by just injecting our config message into our first prompt instead in 177714db10d0dbd1e531efd1fb441c0426a661c4. This resulted in correct behaviour. It probably breaks a ton of tests which rely on the sequence of messages being several user prompts in a row.