### PR TITLE
dockerfile: fix chrome install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,46 @@
 # Use the official Node.js image as a base
-FROM node:18-slim AS base
+FROM --platform=linux/amd64 node:18-slim AS base
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
 FROM base
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+RUN apt-get install -y ca-certificates \
+fonts-liberation \
+libasound2 \
+libatk-bridge2.0-0 \
+libatk1.0-0 \
+libc6 \
+libcairo2 \
+libcups2 \
+libdbus-1-3 \
+libexpat1 \
+libfontconfig1 \
+libgbm1 \
+libgcc1 \
+libglib2.0-0 \
+libgtk-3-0 \
+libnspr4 \
+libnss3 \
+libpango-1.0-0 \
+libpangocairo-1.0-0 \
+libstdc++6 \
+libx11-6 \
+libx11-xcb1 \
+libxcb1 \
+libxcomposite1 \
+libxcursor1 \
+libxdamage1 \
+libxext6 \
+libxfixes3 \
+libxi6 \
+libxrandr2 \
+libxrender1 \
+libxss1 \
+libxtst6 \
+lsb-release \
+wget \
+xdg-utils
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
Kept hitting `11.92 E: Unable to locate package google-chrome-stable` when using Docker. It could be because I'm doing this from M1 (like, the deb repos don't have linux arm64 or something?), whereas when I wrote https://github.com/hdresearch/nolita/commit/a989d5946458b11e494d0fa4c896c61734ed8860 I was not on an M1. I don't know.

- We ensure the Docker install is using an amd64 image;
- we don't need the Chrome install anymore because of #100 but we still need the dependencies, so we get those

*Ideally*, we would copy our local nolitarc into the Docker container's nolitarc so it's seamless. But I can't find a way of doing $HOME folder resolution in the Dockerfile as of yet.

What I end up doing right now is going to the exec section of Docker desktop and just throwing the contents of my nolitarc into it and piping it to .nolitarc there.