### PR TITLE
server: minimum viable solution

### DIFF
--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const browseSchema = z.object({
   startUrl: z.string().url().openapi({ example: "https://google.com" }),


### PR DESCRIPTION
As written on Discord:

> okay SO
for SOME REASON zod resolved to a version of zod monkeypatched with openapi shit from zod-openapi SOMETIMES but not now
but [we should've been using hono's zod-openapi z anyway](https://github.com/honojs/middleware/tree/main/packages/zod-openapi#setting-up-your-application)
with this in mind we should update zod-openapi to latest and then just do as stated in the previous post up here, so that we enforce openapi always resolving, or idk just import { z } from open-api pkg instead in the server

This PR is the second one, just changing the import. If we let this hit `dev` we can test in a Docker container (and locally, I suppose).