### PR TITLE
server: fix openapi crashes

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -2,7 +2,7 @@ name: Push alpha artifact to npm
 on:
   push:
     branches:
-      - mp/tester
+      - dev
 
 jobs:
   test:
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
-          pnpm version prerelease --preid experimental.$git_hash --no-git-tag-version
-          pnpm publish --tag experimental --no-git-checks
+          pnpm version prerelease --preid alpha.$git_hash --no-git-tag-version
+          pnpm publish --tag alpha --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -2,7 +2,7 @@ name: Push alpha artifact to npm
 on:
   push:
     branches:
-      - dev
+      - mp/tester
 
 jobs:
   test:
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
-          pnpm version prerelease --preid alpha.$git_hash --no-git-tag-version
-          pnpm publish --tag alpha --no-git-checks
+          pnpm version prerelease --preid experimental.$git_hash --no-git-tag-version
+          pnpm publish --tag experimental --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/src/server/browser/close.ts
+++ b/src/server/browser/close.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "./launch";
 

--- a/src/server/browser/launch.ts
+++ b/src/server/browser/launch.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { Logger, generateUUID } from "../../utils";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,8 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Hono } from "hono"; // this must be left in for setupServer to work
 import { serve } from "@hono/node-server";
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { JsonSchema } from "json-schema-to-zod";
 import { swaggerUI } from "@hono/swagger-ui";
 
@@ -19,6 +18,7 @@ import { completionApiBuilder } from "../agent";
 import { pageRouter } from "./pages";
 import { browserRouter } from "./browser";
 import { nolitarc } from "../utils/config";
+
 
 export const setupServer = () => {
   const app = new OpenAPIHono();

--- a/src/server/pages/browse.ts
+++ b/src/server/pages/browse.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/close.ts
+++ b/src/server/pages/close.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/content.ts
+++ b/src/server/pages/content.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/do.ts
+++ b/src/server/pages/do.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/get.ts
+++ b/src/server/pages/get.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { JsonSchema } from "json-schema-to-zod";

--- a/src/server/pages/goto.ts
+++ b/src/server/pages/goto.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/info.ts
+++ b/src/server/pages/info.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/list.ts
+++ b/src/server/pages/list.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/newPage.ts
+++ b/src/server/pages/newPage.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/screenshot.ts
+++ b/src/server/pages/screenshot.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/step.ts
+++ b/src/server/pages/step.ts
@@ -1,5 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const browseSchema = z.object({
   startUrl: z.string().url().openapi({ example: "https://google.com" }),

--- a/src/server/schemas/agentSchemas.ts
+++ b/src/server/schemas/agentSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const AgentSchema = z.object({
   provider: z.string().default("openai").openapi({ example: "openai" }),

--- a/src/types/browser/actionStep.types.ts
+++ b/src/types/browser/actionStep.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/objectiveState.types.ts
+++ b/src/types/browser/objectiveState.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const StateType = z.enum(["html", "text", "markdown", "image", "aria"]);
 export type StateType = z.infer<typeof StateType>;


### PR DESCRIPTION
`npx nolita@experimental` is working on a Docker container, so this seems to work.

Still, not sure how I feel about the solution. You need to anticipate how a zod object will be used *elsewhere* and then change the import. Extending our home `z` with `extendZodWithOpenApi` from `@hono/zod-openapi@0.14.9` would be preferred, at the earliest possible z call we do in the stack, but it causes crashes all over the places when you do that...it could be due to them [bumping this dependency up a few major versions](https://github.com/honojs/middleware/blob/main/packages/zod-openapi/CHANGELOG.md#0145).

My actual recommendation is to rip out every time we use `.openapi()` and then reimplement it with `0.14.9` from scratch.