### PR TITLE
package: restore types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nolita",
   "version": "2.1.2",
   "description": "",
-  "main": "dist/index.js",
+  "main": "./dist/index.js",
   "files": [
     "dist/**/*"
   ],
@@ -16,9 +16,9 @@
     "server": "npx tsx ./src/server/index.ts"
   },
   "bin": {
-    "nolita": "dist/bin/index.js"
+    "nolita": "./dist/bin/index.js"
   },
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "keywords": [],
   "author": "HDR",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "bin": {
     "nolita": "dist/bin/index.js"
   },
+  "types": "dist/types/index.d.ts",
   "keywords": [],
   "author": "HDR",
   "license": "MIT",


### PR DESCRIPTION
Removed by me because it didn't seem like we needed them [but we probably do](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package).