### PR TITLE
various: update zod/openapi, consolidate zod location

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -2,7 +2,7 @@ name: Push alpha artifact to npm
 on:
   push:
     branches:
-      - dev
+      - mp/zod
 
 jobs:
   test:
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
-          pnpm version prerelease --preid alpha.$git_hash --no-git-tag-version
-          pnpm publish --tag alpha --no-git-checks
+          pnpm version prerelease --preid experimental.$git_hash --no-git-tag-version
+          pnpm publish --tag experimental --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -2,7 +2,7 @@ name: Push alpha artifact to npm
 on:
   push:
     branches:
-      - mp/zod
+      - dev
 
 jobs:
   test:
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "matilde.park@hdr.is"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
-          pnpm version prerelease --preid experimental.$git_hash --no-git-tag-version
-          pnpm publish --tag experimental --no-git-checks
+          pnpm version prerelease --preid alpha.$git_hash --no-git-tag-version
+          pnpm publish --tag alpha --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/examples/findEmail.ts
+++ b/examples/findEmail.ts
@@ -5,12 +5,12 @@ import { z } from "zod";
 async function main() {
   // If you run npx nolita auth, and save your keys during any `npx nolita` session,
   // you can simply use the following instead:
-  // 
+  //
   // const agent = makeAgent();
-  // 
+  //
   const agent = makeAgent(
     { apiKey: process.env.OPENAI_API_KEY!, provider: "openai" },
-    { model: "gpt-4" }
+    { model: "gpt-4" },
   );
 
   const browser = await Browser.launch(false, agent);
@@ -26,7 +26,7 @@ async function main() {
       emails: z
         .array(z.string())
         .describe("The email addresses found on the page"),
-    })
+    }),
   );
 
   console.log(answer);

--- a/examples/followRoute.ts
+++ b/examples/followRoute.ts
@@ -10,7 +10,7 @@ async function makeRoute(browser: Browser, schema: z.ZodObject<any>) {
   await page.do("click on the company link");
   const answer = await page.get(
     "Find all the email addresses on the page",
-    schema
+    schema,
   );
 
   console.log(answer);
@@ -20,7 +20,7 @@ async function makeRoute(browser: Browser, schema: z.ZodObject<any>) {
 async function followRoute(
   browser: Browser,
   routeId: string,
-  schema: z.ZodObject<any>
+  schema: z.ZodObject<any>,
 ) {
   const page = await browser.newPage();
 
@@ -31,7 +31,7 @@ async function followRoute(
 async function main() {
   const agent = makeAgent(
     { provider: "openai", apiKey: process.env.OPENAI_API_KEY! },
-    { model: "gpt-4" }
+    { model: "gpt-4" },
   );
   const logger = new Logger(["info"], (msg) => console.log(msg));
   const browser = await Browser.launch(false, agent, logger);

--- a/examples/login.ts
+++ b/examples/login.ts
@@ -35,7 +35,7 @@ async function main() {
 
   if (!chatApi) {
     throw new Error(
-      `Failed to create chat api for ${providerOptions.provider}`
+      `Failed to create chat api for ${providerOptions.provider}`,
     );
   }
 
@@ -62,7 +62,7 @@ async function main() {
   const page = await browser.newPage();
   await page.goto(startUrl);
   const answer = await page.browse(objective, {
-    maxTurns: maxIterations
+    maxTurns: maxIterations,
   });
   // @ts-expect-error - we are not using the full response schema
   console.log("Answer:", answer?.objectiveComplete?.result);

--- a/examples/shopping.ts
+++ b/examples/shopping.ts
@@ -30,11 +30,13 @@ async function main() {
     apiKey: agentApiKey || process.env.OPENAI_API_KEY!,
     provider: agentProvider || "openai",
   };
-  const chatApi = completionApiBuilder(providerOptions, { model: agentModel || "gpt-4" });
+  const chatApi = completionApiBuilder(providerOptions, {
+    model: agentModel || "gpt-4",
+  });
 
   if (!chatApi) {
     throw new Error(
-      `Failed to create chat api for ${providerOptions.provider}`
+      `Failed to create chat api for ${providerOptions.provider}`,
     );
   }
   const logger = new Logger(["info"], (msg) => console.log(msg));
@@ -48,7 +50,9 @@ async function main() {
   const answer = await page.browse(objective, {
     maxTurns: maxIterations,
     schema: z.object({
-      orderTotals: z.array(z.number()).describe("The order total in number format"),
+      orderTotals: z
+        .array(z.number())
+        .describe("The order total in number format"),
     }),
     inventory: new Inventory([
       { value: "emma.lopez@gmail.com", name: "email", type: "string" },
@@ -56,7 +60,10 @@ async function main() {
     ]),
   });
   // @ts-expect-error - we are not using the full response schema
-  console.log("\x1b[32m Answer:", JSON.stringify(answer?.objectiveComplete?.orderTotals));
+  console.log(
+    "\x1b[32m Answer:",
+    JSON.stringify(answer?.objectiveComplete?.orderTotals),
+  );
   await browser.close();
 }
 

--- a/examples/wikipedia.ts
+++ b/examples/wikipedia.ts
@@ -26,11 +26,13 @@ async function main() {
     apiKey: agentApiKey || process.env.OPENAI_API_KEY!,
     provider: agentProvider || "openai",
   };
-  const chatApi = completionApiBuilder(providerOptions, { model: agentModel || "gpt-4" });
+  const chatApi = completionApiBuilder(providerOptions, {
+    model: agentModel || "gpt-4",
+  });
 
   if (!chatApi) {
     throw new Error(
-      `Failed to create chat api for ${providerOptions.provider}`
+      `Failed to create chat api for ${providerOptions.provider}`,
     );
   }
   const logger = new Logger(["info"], (msg) => console.log(msg));
@@ -39,12 +41,18 @@ async function main() {
   const browser = await Browser.launch(argv.headless, agent, logger);
   const page = await browser.newPage();
   await page.goto(argv.startUrl || "https://google.com");
-  const answer = await page.browse(argv.objective || "How many accounts are on Wikipedia?", {
-    maxTurns: argv.maxIterations || 10,
-    schema: z.object({
-      numberOfEditors: z.number().int().describe("The number of accounts in int format"),
-    }),
-  });
+  const answer = await page.browse(
+    argv.objective || "How many accounts are on Wikipedia?",
+    {
+      maxTurns: argv.maxIterations || 10,
+      schema: z.object({
+        numberOfEditors: z
+          .number()
+          .int()
+          .describe("The number of accounts in int format"),
+      }),
+    },
+  );
 
   // @ts-expect-error - we are not using the full response schema
   console.log("Answer:", answer?.objectiveComplete?.numberOfEditors);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky",
     "lint": "eslint .",
     "build": "rm -rf ./dist && tsc",
+    "ver": "tsc -v",
     "build:docs": "./build-docs.sh",
     "build:openapi": "node --import tsx ./dev_utils/generateOpenApiSpec.ts",
     "test": "jest",
@@ -50,7 +51,7 @@
     "turndown": "^7.1.3",
     "type-fest": "^4.10.2",
     "typescript": "~5.3.3",
-    "zod": "3.22.4"
+    "zod": "^3.23.3"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@hono/node-server": ">=1.10.1",
     "@hono/swagger-ui": "^0.2.1",
-    "@hono/zod-openapi": "^0.9.8",
+    "@hono/zod-openapi": "^0.15.0",
     "@hono/zod-validator": "^0.2.0",
     "@instructor-ai/instructor": "^1.5.0",
     "@types/inquirer": "^9.0.7",
@@ -50,7 +50,7 @@
     "turndown": "^7.1.3",
     "type-fest": "^4.10.2",
     "typescript": "~5.3.3",
-    "zod": "^3.23.8"
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,22 +13,22 @@ importers:
         version: 1.12.0
       '@hono/swagger-ui':
         specifier: ^0.2.1
-        version: 0.2.2(hono@4.4.12)
+        version: 0.2.2(hono@4.5.0)
       '@hono/zod-openapi':
         specifier: ^0.15.0
-        version: 0.15.0(hono@4.4.12)(zod@3.22.4)
+        version: 0.15.0(hono@4.5.0)(zod@3.23.8)
       '@hono/zod-validator':
         specifier: ^0.2.0
-        version: 0.2.2(hono@4.4.12)(zod@3.22.4)
+        version: 0.2.2(hono@4.5.0)(zod@3.23.8)
       '@instructor-ai/instructor':
         specifier: ^1.5.0
-        version: 1.5.0(openai@4.52.4)(zod@3.22.4)
+        version: 1.5.0(openai@4.52.7)(zod@3.23.8)
       '@types/inquirer':
         specifier: ^9.0.7
         version: 9.0.7
       '@types/lodash':
         specifier: ^4.14.202
-        version: 4.17.6
+        version: 4.17.7
       '@types/turndown':
         specifier: ^5.0.4
         version: 5.0.4
@@ -49,13 +49,13 @@ importers:
         version: 5.1.6(debug@4.3.5)
       hono:
         specifier: ^4.1.1
-        version: 4.4.12
+        version: 4.5.0
       json-schema-to-zod:
         specifier: ^2.0.14
-        version: 2.3.0
+        version: 2.3.1
       llm-polyglot:
         specifier: ^2.0.0
-        version: 2.0.0(@anthropic-ai/sdk@0.22.0)(openai@4.52.4)
+        version: 2.0.0(@anthropic-ai/sdk@0.22.0)(openai@4.52.7)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -64,19 +64,19 @@ importers:
         version: 2.8.12(typescript@5.3.3)
       openai:
         specifier: ^4.51.0
-        version: 4.52.4
+        version: 4.52.7
       out-url:
         specifier: ^1.2.2
         version: 1.2.2
       puppeteer:
         specifier: ^22.0.0
-        version: 22.12.1(typescript@5.3.3)
+        version: 22.13.1(typescript@5.3.3)
       puppeteer-extra:
         specifier: ^3.3.6
-        version: 3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))
+        version: 3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))
       puppeteer-extra-plugin-stealth:
         specifier: ^2.11.2
-        version: 2.11.2(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)))
+        version: 2.11.2(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)))
       simple-git:
         specifier: ^3.24.0
         version: 3.25.0
@@ -85,13 +85,13 @@ importers:
         version: 7.2.0
       type-fest:
         specifier: ^4.10.2
-        version: 4.21.0
+        version: 4.22.1
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
       zod:
-        specifier: 3.22.4
-        version: 3.22.4
+        specifier: ^3.23.3
+        version: 3.23.8
     devDependencies:
       '@eslint/js':
         specifier: ^8.56.0
@@ -116,43 +116,43 @@ importers:
         version: 15.8.0
       husky:
         specifier: ^9.0.11
-        version: 9.0.11
+        version: 9.1.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+        version: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       jest-puppeteer:
         specifier: ^10.0.1
-        version: 10.0.1(debug@4.3.5)(puppeteer@22.12.1(typescript@5.3.3))(typescript@5.3.3)
+        version: 10.0.1(debug@4.3.5)(puppeteer@22.13.1(typescript@5.3.3))(typescript@5.3.3)
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
       ts-jest:
         specifier: ^29.1.2
-        version: 29.2.0(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3)))(typescript@5.3.3)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3)))(typescript@5.3.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.14.10)(typescript@5.3.3)
+        version: 10.9.2(@types/node@20.14.11)(typescript@5.3.3)
       tsx:
         specifier: ^4.7.1
         version: 4.16.2
       typedoc:
         specifier: ^0.26.0
-        version: 0.26.3(typescript@5.3.3)
+        version: 0.26.4(typescript@5.3.3)
       typedoc-plugin-markdown:
         specifier: ^4.1.2
-        version: 4.1.2(typedoc@0.26.3(typescript@5.3.3))
+        version: 4.2.1(typedoc@0.26.4(typescript@5.3.3))
       typedoc-plugin-zod:
         specifier: ^1.1.2
-        version: 1.2.0(typedoc@0.26.3(typescript@5.3.3))
+        version: 1.2.0(typedoc@0.26.4(typescript@5.3.3))
       typescript-eslint:
         specifier: ^7.16.0
-        version: 7.16.0(eslint@8.57.0)(typescript@5.3.3)
+        version: 7.16.1(eslint@8.57.0)(typescript@5.3.3)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
       zod-to-json-schema:
         specifier: ^3.23.0
-        version: 3.23.1(zod@3.22.4)
+        version: 3.23.1(zod@3.23.8)
 
 packages:
 
@@ -172,20 +172,20 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.24.7':
-    resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
+  '@babel/compat-data@7.24.9':
+    resolution: {integrity: sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.24.7':
-    resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
+  '@babel/core@7.24.9':
+    resolution: {integrity: sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.24.7':
-    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
+  '@babel/generator@7.24.10':
+    resolution: {integrity: sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.24.7':
-    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
+  '@babel/helper-compilation-targets@7.24.8':
+    resolution: {integrity: sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-environment-visitor@7.24.7':
@@ -204,14 +204,14 @@ packages:
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.24.7':
-    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
+  '@babel/helper-module-transforms@7.24.9':
+    resolution: {integrity: sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.24.7':
-    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
+  '@babel/helper-plugin-utils@7.24.8':
+    resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-simple-access@7.24.7':
@@ -222,28 +222,28 @@ packages:
     resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.7':
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
+  '@babel/helper-string-parser@7.24.8':
+    resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.24.7':
-    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
+  '@babel/helper-validator-option@7.24.8':
+    resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.24.7':
-    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
+  '@babel/helpers@7.24.8':
+    resolution: {integrity: sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.24.7':
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
+  '@babel/parser@7.24.8':
+    resolution: {integrity: sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -324,12 +324,12 @@ packages:
     resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.24.7':
-    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
+  '@babel/traverse@7.24.8':
+    resolution: {integrity: sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.24.7':
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
+  '@babel/types@7.24.9':
+    resolution: {integrity: sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -777,8 +777,8 @@ packages:
     resolution: {integrity: sha512-CyuLJ0/P7bKZ+kIYw+fnkeVdhUzNuDKgNSI7pU/m7Nod0T7kP+s4s2f0pNmG9HL8/RZN1S0ZWTDll3VTMrFLAw==}
     engines: {node: '>= 18'}
 
-  '@puppeteer/browsers@2.2.3':
-    resolution: {integrity: sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==}
+  '@puppeteer/browsers@2.2.4':
+    resolution: {integrity: sha512-BdG2qiI1dn89OTUUsx2GZSpUzW+DRffR1wlMJyKxVHYrhnKoELSDxDd+2XImUkuWPEKk76H5FcM/gPFrEK1Tfw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -818,8 +818,8 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@types/aws-lambda@8.10.140':
-    resolution: {integrity: sha512-4Dh3dk2TUcbdfHrX0Al90mNGJDvA9NBiTQPzbrjGi/dLxzKCGOYgT8YQ47jUKNFALkAJAadifq0pzyjIUlhVhg==}
+  '@types/aws-lambda@8.10.141':
+    resolution: {integrity: sha512-SMWlRBukG9KV8ZNjwemp2AzDibp/czIAeKKTw09nCPbWxVskIxactCJCGOp4y6I1hCMY7T7UGfySvBLXNeUbEw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -863,8 +863,8 @@ packages:
   '@types/jsonwebtoken@9.0.6':
     resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
 
-  '@types/lodash@4.17.6':
-    resolution: {integrity: sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==}
+  '@types/lodash@4.17.7':
+    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -875,11 +875,11 @@ packages:
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
 
-  '@types/node@18.19.39':
-    resolution: {integrity: sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==}
+  '@types/node@18.19.41':
+    resolution: {integrity: sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==}
 
-  '@types/node@20.14.10':
-    resolution: {integrity: sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==}
+  '@types/node@20.14.11':
+    resolution: {integrity: sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -911,8 +911,8 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@7.16.0':
-    resolution: {integrity: sha512-py1miT6iQpJcs1BiJjm54AMzeuMPBSPuKPlnT8HlfudbcS5rYeX5jajpLf3mrdRh9dA/Ec2FVUY0ifeVNDIhZw==}
+  '@typescript-eslint/eslint-plugin@7.16.1':
+    resolution: {integrity: sha512-SxdPak/5bO0EnGktV05+Hq8oatjAYVY3Zh2bye9pGZy6+jwyR3LG3YKkV4YatlsgqXP28BTeVm9pqwJM96vf2A==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^7.0.0
@@ -922,8 +922,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@7.16.0':
-    resolution: {integrity: sha512-ar9E+k7CU8rWi2e5ErzQiC93KKEFAXA2Kky0scAlPcxYblLt8+XZuHUZwlyfXILyQa95P6lQg+eZgh/dDs3+Vw==}
+  '@typescript-eslint/parser@7.16.1':
+    resolution: {integrity: sha512-u+1Qx86jfGQ5i4JjK33/FnawZRpsLxRnKzGE6EABZ40KxVT/vWsiZFEBBHjFOljmmV3MBYOHEKi0Jm9hbAOClA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -932,12 +932,12 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@7.16.0':
-    resolution: {integrity: sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==}
+  '@typescript-eslint/scope-manager@7.16.1':
+    resolution: {integrity: sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/type-utils@7.16.0':
-    resolution: {integrity: sha512-j0fuUswUjDHfqV/UdW6mLtOQQseORqfdmoBNDFOqs9rvNVR2e+cmu6zJu/Ku4SDuqiJko6YnhwcL8x45r8Oqxg==}
+  '@typescript-eslint/type-utils@7.16.1':
+    resolution: {integrity: sha512-rbu/H2MWXN4SkjIIyWcmYBjlp55VT+1G3duFOIukTNFxr9PI35pLc2ydwAfejCEitCv4uztA07q0QWanOHC7dA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -946,12 +946,12 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/types@7.16.0':
-    resolution: {integrity: sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==}
+  '@typescript-eslint/types@7.16.1':
+    resolution: {integrity: sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/typescript-estree@7.16.0':
-    resolution: {integrity: sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==}
+  '@typescript-eslint/typescript-estree@7.16.1':
+    resolution: {integrity: sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
@@ -959,14 +959,14 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/utils@7.16.0':
-    resolution: {integrity: sha512-PqP4kP3hb4r7Jav+NiRCntlVzhxBNWq6ZQ+zQwII1y/G/1gdIPeYDCKr2+dH6049yJQsWZiHU6RlwvIFBXXGNA==}
+  '@typescript-eslint/utils@7.16.1':
+    resolution: {integrity: sha512-WrFM8nzCowV0he0RlkotGDujx78xudsxnGMBHI88l5J8wEhED6yBwaSLP99ygfrzAjsQvcYQ94quDwI0d7E1fA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
-  '@typescript-eslint/visitor-keys@7.16.0':
-    resolution: {integrity: sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==}
+  '@typescript-eslint/visitor-keys@7.16.1':
+    resolution: {integrity: sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@ungap/structured-clone@1.2.0':
@@ -1209,8 +1209,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001640:
-    resolution: {integrity: sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==}
+  caniuse-lite@1.0.30001642:
+    resolution: {integrity: sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1238,8 +1238,8 @@ packages:
   chrome-paths@1.0.1:
     resolution: {integrity: sha512-yeWKB6TDWUL6qJDYGq14Z/ZT+/+dDVFF3hHd+R+D6+Yq7Z0fWwJvgZwzDC/14H7yN8qlC/cWQmVq3odOakX8GA==}
 
-  chromium-bidi@0.5.24:
-    resolution: {integrity: sha512-5xQNN2SVBdZv4TxeMLaI+PelrnZsHDhn8h2JtyriLr+0qHcZS8BMuo93qN6J1VmtmrgYP+rmcLHcbpnA8QJh+w==}
+  chromium-bidi@0.6.1:
+    resolution: {integrity: sha512-kSxJRj0VgtUKz6nmzc2JPfyfJGzwzt65u7PqhPHtgGQUZLF5oG+ST6l6e5ONfStUMAlhSutFCjaGKllXZa16jA==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -1389,15 +1389,6 @@ packages:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
 
-  debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
@@ -1483,13 +1474,18 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   ejs@3.1.8:
     resolution: {integrity: sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.4.820:
-    resolution: {integrity: sha512-kK/4O/YunacfboFEk/BDf7VO1HoPmDudLTJAU9NmXIOSjsV7qVIX3OrI4REZo0VmdqhcpUcncQc6N8Q3aEXlHg==}
+  electron-to-chromium@1.4.829:
+    resolution: {integrity: sha512-5qp1N2POAfW0u1qGAxXEtz6P7bO1m6gpZr5hdf5ve6lxpLM7MpiM4jIPz7xcrNlClQMafbyUDDWjlIQZ1Mw0Rw==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1881,8 +1877,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.4.12:
-    resolution: {integrity: sha512-Lx4Vwbws0IqFfXIVYychxUW0A4EE+7dn/jsjVeM34OXSA2Xs45MkDDP14Mzznp7LlDemUNHQG2uv2N5jQld0hA==}
+  hono@4.5.0:
+    resolution: {integrity: sha512-ZbezypZfn4odyApjCCv+Fw5OgweBqRLA/EsMyc4FUknFvBJcBIKhHy4sqmD1rWpBc/3wUlaQ6tqOPjk36R1ckg==}
     engines: {node: '>=16.0.0'}
 
   html-escaper@2.0.2:
@@ -1903,8 +1899,8 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
-  husky@9.0.11:
-    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+  husky@9.1.1:
+    resolution: {integrity: sha512-fCqlqLXcBnXa/TJXmT93/A36tJsjdJkibQ1MuIiFyCCYUlpYpIaj2mv1w+3KR6Rzu1IC3slFTje5f6DUp2A2rg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1952,8 +1948,8 @@ packages:
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
-  is-core-module@2.14.0:
-    resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
+  is-core-module@2.15.0:
+    resolution: {integrity: sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==}
     engines: {node: '>= 0.4'}
 
   is-extendable@0.1.1:
@@ -2219,8 +2215,8 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-schema-to-zod@2.3.0:
-    resolution: {integrity: sha512-3PBkl6oAApHMSNQE2I7W34O8H97bmVbIzfSQr3sSg+BxJbkqJmEDzxa2nrg69o+8OJv5/H0GQSKNOibRfrxzRQ==}
+  json-schema-to-zod@2.3.1:
+    resolution: {integrity: sha512-mxj4nDqbh6H0PPslVwG8z0w9uvckSyin/j4BMD818l/3E1Ie4L6x77itCVJ29ejZI67cUgBoZGsUB69WGc6b/g==}
     hasBin: true
 
   json-schema-traverse@0.4.1:
@@ -2511,12 +2507,11 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  node-addon-api@7.1.0:
-    resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}
-    engines: {node: ^16 || ^18 || >= 20}
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-api-headers@1.1.0:
-    resolution: {integrity: sha512-ucQW+SbYCUPfprvmzBsnjT034IGRB2XK8rRc78BgjNKhTdFKgAwAmgW704bKIBmcYW48it0Gkjpkd39Azrwquw==}
+  node-api-headers@1.2.0:
+    resolution: {integrity: sha512-L9AiEkBfgupC0D/LsudLPOhzy/EdObsp+FHyL1zSK0kKv5FDA9rJMoRz8xd+ojxzlqfg0tTZm2h8ot2nS7bgRA==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -2544,8 +2539,8 @@ packages:
       typescript:
         optional: true
 
-  node-releases@2.0.14:
-    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+  node-releases@2.0.17:
+    resolution: {integrity: sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2583,8 +2578,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openai@4.52.4:
-    resolution: {integrity: sha512-3CkV7e8epJBnTe5ptn4i3ivfm1d8cvkbvBOzhGmGYEarpDpcCgwOMV1aBPvZ/HoveUtREWUE9Fqcy7BcPNtMJg==}
+  openai@4.52.7:
+    resolution: {integrity: sha512-dgxA6UZHary6NXUHEDj5TWt8ogv0+ibH+b4pT5RrWMjiRZVylNwLcw/2ubDrX5n0oUmHX/ZgudMJeemxzOvz7A==}
     hasBin: true
 
   openapi3-ts@4.3.3:
@@ -2724,8 +2719,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer-core@22.12.1:
-    resolution: {integrity: sha512-XmqeDPVdC5/3nGJys1jbgeoZ02wP0WV1GBlPtr/ULRbGXJFuqgXMcKQ3eeNtFpBzGRbpeoCGWHge1ZWKWl0Exw==}
+  puppeteer-core@22.13.1:
+    resolution: {integrity: sha512-NmhnASYp51QPRCAf9n0OPxuPMmzkKd8+2sB9Q+BjwwCG25gz6iuNc3LQDWa+cH2tyivmJppLhNNFt6Q3HmoOpw==}
     engines: {node: '>=18'}
 
   puppeteer-extra-plugin-stealth@2.11.2:
@@ -2791,8 +2786,8 @@ packages:
       puppeteer-core:
         optional: true
 
-  puppeteer@22.12.1:
-    resolution: {integrity: sha512-1GxY8dnEnHr1SLzdSDr0FCjM6JQfAh2E2I/EqzeF8a58DbGVk9oVjj4lFdqNoVbpgFSpAbz7VER9St7S1wDpNg==}
+  puppeteer@22.13.1:
+    resolution: {integrity: sha512-PwXLDQK5u83Fm5A7TGMq+9BR7iHDJ8a3h21PSsh/E6VfhxiKYkU7+tvGZNSCap6k3pCNDd9oNteVBEctcBalmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2899,13 +2894,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.6.2:
-    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3059,8 +3049,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tar-fs@3.0.5:
-    resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
+  tar-fs@3.0.6:
+    resolution: {integrity: sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -3106,8 +3096,8 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
-  ts-jest@29.2.0:
-    resolution: {integrity: sha512-eFmkE9MG0+oT6nqSOcUwL+2UUmK2IvhhUV8hFDsCHnc++v2WCCbQQZh5vvjsa8sgOY/g9T0325hmkEmi6rninA==}
+  ts-jest@29.2.3:
+    resolution: {integrity: sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3171,12 +3161,12 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@4.21.0:
-    resolution: {integrity: sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==}
+  type-fest@4.22.1:
+    resolution: {integrity: sha512-9tHNEa0Ov81YOopiVkcCJVz5TM6AEQ+CHHjFIktqPnE3NV0AHIkx+gh9tiCl58m/66wWxkOC9eltpa75J4lQPA==}
     engines: {node: '>=16'}
 
-  typedoc-plugin-markdown@4.1.2:
-    resolution: {integrity: sha512-jZt8jmQLbmg9jmFQyfJrjLf6ljRwJ5fKMeqmFr0oPXmeX5ZRYYtCe6y/058vDESE/R+TwEvNua6SuG43UBbszw==}
+  typedoc-plugin-markdown@4.2.1:
+    resolution: {integrity: sha512-7hQt/1WaW/VI4+x3sxwcCGsEylP1E1GvF6OTTELK5sfTEp6AeK+83jkCOgZGp1pI2DiOammMYQMnxxOny9TKsQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       typedoc: 0.26.x
@@ -3186,15 +3176,15 @@ packages:
     peerDependencies:
       typedoc: 0.23.x || 0.24.x || 0.25.x || 0.26.x
 
-  typedoc@0.26.3:
-    resolution: {integrity: sha512-6d2Sw9disvvpdk4K7VNjKr5/3hzijtfQVHRthhDqJgnhMHy1wQz4yPMJVKXElvnZhFr0nkzo+GzjXDTRV5yLpg==}
+  typedoc@0.26.4:
+    resolution: {integrity: sha512-FlW6HpvULDKgc3rK04V+nbFyXogPV88hurarDPOjuuB5HAwuAlrCMQ5NeH7Zt68a/ikOKu6Z/0hFXAeC9xPccQ==}
     engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x
 
-  typescript-eslint@7.16.0:
-    resolution: {integrity: sha512-kaVRivQjOzuoCXU6+hLnjo3/baxyzWVO5GrnExkFzETRYJKVHYkrJglOu2OCm8Hi9RPDWX1PTNNTpU5KRV0+RA==}
+  typescript-eslint@7.16.1:
+    resolution: {integrity: sha512-889oE5qELj65q/tGeOSvlreNKhimitFwZqQ0o7PcWC7/lgRkAMknznsCsV8J8mZGTP/Z+cIbX8accf2DE33hrA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -3380,9 +3370,6 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
@@ -3395,7 +3382,7 @@ snapshots:
 
   '@anthropic-ai/sdk@0.22.0':
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.41
       '@types/node-fetch': 2.6.11
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -3406,30 +3393,30 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@asteasolutions/zod-to-openapi@7.1.1(zod@3.22.4)':
+  '@asteasolutions/zod-to-openapi@7.1.1(zod@3.23.8)':
     dependencies:
       openapi3-ts: 4.3.3
-      zod: 3.22.4
+      zod: 3.23.8
 
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
       picocolors: 1.0.1
 
-  '@babel/compat-data@7.24.7': {}
+  '@babel/compat-data@7.24.9': {}
 
-  '@babel/core@7.24.7':
+  '@babel/core@7.24.9':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
-      '@babel/helpers': 7.24.7
-      '@babel/parser': 7.24.7
+      '@babel/generator': 7.24.10
+      '@babel/helper-compilation-targets': 7.24.8
+      '@babel/helper-module-transforms': 7.24.9(@babel/core@7.24.9)
+      '@babel/helpers': 7.24.8
+      '@babel/parser': 7.24.8
       '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.24.8
+      '@babel/types': 7.24.9
       convert-source-map: 2.0.0
       debug: 4.3.5
       gensync: 1.0.0-beta.2
@@ -3438,44 +3425,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.24.7':
+  '@babel/generator@7.24.10':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
-  '@babel/helper-compilation-targets@7.24.7':
+  '@babel/helper-compilation-targets@7.24.8':
     dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
+      '@babel/compat-data': 7.24.9
+      '@babel/helper-validator-option': 7.24.8
       browserslist: 4.23.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.24.8
+      '@babel/types': 7.24.9
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.24.7(@babel/core@7.24.7)':
+  '@babel/helper-module-transforms@7.24.9(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
@@ -3484,29 +3471,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.24.7': {}
+  '@babel/helper-plugin-utils@7.24.8': {}
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.24.8
+      '@babel/types': 7.24.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
-  '@babel/helper-string-parser@7.24.7': {}
+  '@babel/helper-string-parser@7.24.8': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
-  '@babel/helper-validator-option@7.24.7': {}
+  '@babel/helper-validator-option@7.24.8': {}
 
-  '@babel/helpers@7.24.7':
+  '@babel/helpers@7.24.8':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -3515,104 +3502,104 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.0.1
 
-  '@babel/parser@7.24.7':
+  '@babel/parser@7.24.8':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.7)':
+  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.24.8
+      '@babel/types': 7.24.9
 
-  '@babel/traverse@7.24.7':
+  '@babel/traverse@7.24.8':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
+      '@babel/generator': 7.24.10
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.24.8
+      '@babel/types': 7.24.9
       debug: 4.3.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.24.7':
+  '@babel/types@7.24.9':
     dependencies:
-      '@babel/helper-string-parser': 7.24.7
+      '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
@@ -3722,21 +3709,21 @@ snapshots:
 
   '@hono/node-server@1.12.0': {}
 
-  '@hono/swagger-ui@0.2.2(hono@4.4.12)':
+  '@hono/swagger-ui@0.2.2(hono@4.5.0)':
     dependencies:
-      hono: 4.4.12
+      hono: 4.5.0
 
-  '@hono/zod-openapi@0.15.0(hono@4.4.12)(zod@3.22.4)':
+  '@hono/zod-openapi@0.15.0(hono@4.5.0)(zod@3.23.8)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 7.1.1(zod@3.22.4)
-      '@hono/zod-validator': 0.2.2(hono@4.4.12)(zod@3.22.4)
-      hono: 4.4.12
-      zod: 3.22.4
+      '@asteasolutions/zod-to-openapi': 7.1.1(zod@3.23.8)
+      '@hono/zod-validator': 0.2.2(hono@4.5.0)(zod@3.23.8)
+      hono: 4.5.0
+      zod: 3.23.8
 
-  '@hono/zod-validator@0.2.2(hono@4.4.12)(zod@3.22.4)':
+  '@hono/zod-validator@0.2.2(hono@4.5.0)(zod@3.23.8)':
     dependencies:
-      hono: 4.4.12
-      zod: 3.22.4
+      hono: 4.5.0
+      zod: 3.23.8
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -3750,12 +3737,12 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@instructor-ai/instructor@1.5.0(openai@4.52.4)(zod@3.22.4)':
+  '@instructor-ai/instructor@1.5.0(openai@4.52.7)(zod@3.23.8)':
     dependencies:
-      openai: 4.52.4
-      zod: 3.22.4
-      zod-stream: 1.0.3(openai@4.52.4)(zod@3.22.4)
-      zod-validation-error: 2.1.0(zod@3.22.4)
+      openai: 4.52.7
+      zod: 3.23.8
+      zod-stream: 1.0.3(openai@4.52.7)(zod@3.23.8)
+      zod-validation-error: 2.1.0(zod@3.23.8)
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -3770,27 +3757,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3815,7 +3802,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3833,7 +3820,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3855,7 +3842,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3902,7 +3889,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -3925,7 +3912,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -4057,7 +4044,7 @@ snapshots:
       '@octokit/core': 5.2.0
       '@octokit/oauth-authorization-url': 6.0.2
       '@octokit/oauth-methods': 4.1.0
-      '@types/aws-lambda': 8.10.140
+      '@types/aws-lambda': 8.10.141
       universal-user-agent: 6.0.1
 
   '@octokit/oauth-authorization-url@6.0.2': {}
@@ -4138,14 +4125,14 @@ snapshots:
       '@octokit/webhooks-types': 7.4.0
       aggregate-error: 3.1.0
 
-  '@puppeteer/browsers@2.2.3':
+  '@puppeteer/browsers@2.2.4':
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.4.0
-      semver: 7.6.0
-      tar-fs: 3.0.5
+      semver: 7.6.3
+      tar-fs: 3.0.6
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -4183,28 +4170,28 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@types/aws-lambda@8.10.140': {}
+  '@types/aws-lambda@8.10.141': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.24.8
+      '@babel/types': 7.24.9
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.24.8
+      '@babel/types': 7.24.9
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
 
   '@types/btoa-lite@1.0.2': {}
 
@@ -4216,7 +4203,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
 
   '@types/hast@3.0.4':
     dependencies:
@@ -4239,9 +4226,9 @@ snapshots:
 
   '@types/jsonwebtoken@9.0.6':
     dependencies:
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
 
-  '@types/lodash@4.17.6': {}
+  '@types/lodash@4.17.7': {}
 
   '@types/methods@1.1.4': {}
 
@@ -4249,14 +4236,14 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.41
       form-data: 4.0.0
 
-  '@types/node@18.19.39':
+  '@types/node@18.19.41':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.14.10':
+  '@types/node@20.14.11':
     dependencies:
       undici-types: 5.26.5
 
@@ -4268,7 +4255,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
 
   '@types/supertest@6.0.2':
     dependencies:
@@ -4277,7 +4264,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
 
   '@types/turndown@5.0.4': {}
 
@@ -4291,17 +4278,17 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@7.16.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.16.0(eslint@8.57.0)(typescript@5.3.3)
-      '@typescript-eslint/scope-manager': 7.16.0
-      '@typescript-eslint/type-utils': 7.16.0(eslint@8.57.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 7.16.0(eslint@8.57.0)(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/type-utils': 7.16.1(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 7.16.1
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -4312,12 +4299,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.3.3)':
+  '@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 7.16.0
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.5
       eslint: 8.57.0
     optionalDependencies:
@@ -4325,15 +4312,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@7.16.0':
+  '@typescript-eslint/scope-manager@7.16.1':
     dependencies:
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/visitor-keys': 7.16.1
 
-  '@typescript-eslint/type-utils@7.16.0(eslint@8.57.0)(typescript@5.3.3)':
+  '@typescript-eslint/type-utils@7.16.1(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.3.3)
-      '@typescript-eslint/utils': 7.16.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.3.3)
       debug: 4.3.5
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
@@ -4342,37 +4329,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@7.16.0': {}
+  '@typescript-eslint/types@7.16.1': {}
 
-  '@typescript-eslint/typescript-estree@7.16.0(typescript@5.3.3)':
+  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.2
+      semver: 7.6.3
       ts-api-utils: 1.3.0(typescript@5.3.3)
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.16.0(eslint@8.57.0)(typescript@5.3.3)':
+  '@typescript-eslint/utils@7.16.1(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 7.16.0
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.3.3)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/visitor-keys@7.16.0':
+  '@typescript-eslint/visitor-keys@7.16.1':
     dependencies:
-      '@typescript-eslint/types': 7.16.0
+      '@typescript-eslint/types': 7.16.1
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -4493,13 +4480,13 @@ snapshots:
 
   b4a@1.6.6: {}
 
-  babel-jest@29.7.0(@babel/core@7.24.7):
+  babel-jest@29.7.0(@babel/core@7.24.9):
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.24.7)
+      babel-preset-jest: 29.6.3(@babel/core@7.24.9)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -4508,7 +4495,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -4519,31 +4506,31 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/types': 7.24.9
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.7):
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.9):
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
+      '@babel/core': 7.24.9
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.9)
 
-  babel-preset-jest@29.6.3(@babel/core@7.24.7):
+  babel-preset-jest@29.6.3(@babel/core@7.24.9):
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.9)
 
   balanced-match@1.0.2: {}
 
@@ -4599,9 +4586,9 @@ snapshots:
 
   browserslist@4.23.2:
     dependencies:
-      caniuse-lite: 1.0.30001640
-      electron-to-chromium: 1.4.820
-      node-releases: 2.0.14
+      caniuse-lite: 1.0.30001642
+      electron-to-chromium: 1.4.829
+      node-releases: 2.0.17
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
 
   bs-logger@0.2.6:
@@ -4644,7 +4631,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001640: {}
+  caniuse-lite@1.0.30001642: {}
 
   chalk@2.4.2:
     dependencies:
@@ -4669,7 +4656,7 @@ snapshots:
     dependencies:
       karma-chrome-launcher: 2.2.0
 
-  chromium-bidi@0.5.24(devtools-protocol@0.0.1299070):
+  chromium-bidi@0.6.1(devtools-protocol@0.0.1299070):
     dependencies:
       devtools-protocol: 0.0.1299070
       mitt: 3.0.1
@@ -4726,10 +4713,10 @@ snapshots:
       fs-extra: 11.2.0
       lodash.isplainobject: 4.0.6
       memory-stream: 1.0.0
-      node-api-headers: 1.1.0
+      node-api-headers: 1.2.0
       npmlog: 6.0.2
       rc: 1.2.8
-      semver: 7.6.2
+      semver: 7.6.3
       tar: 6.2.1
       url-join: 4.0.1
       which: 2.0.2
@@ -4799,13 +4786,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.3.3
 
-  create-jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3)):
+  create-jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4832,10 +4819,6 @@ snapshots:
       fs-exists-sync: 0.1.0
 
   data-uri-to-buffer@6.0.2: {}
-
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
 
   debug@4.3.5:
     dependencies:
@@ -4900,11 +4883,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.1
+
   ejs@3.1.8:
     dependencies:
       jake: 10.9.1
 
-  electron-to-chromium@1.4.820: {}
+  electron-to-chromium@1.4.829: {}
 
   emittery@0.13.1: {}
 
@@ -5389,7 +5376,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.4.12: {}
+  hono@4.5.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -5413,7 +5400,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  husky@9.0.11: {}
+  husky@9.1.1: {}
 
   ieee754@1.2.1: {}
 
@@ -5451,7 +5438,7 @@ snapshots:
 
   is-buffer@1.1.6: {}
 
-  is-core-module@2.14.0:
+  is-core-module@2.15.0:
     dependencies:
       hasown: 2.0.2
 
@@ -5495,8 +5482,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/parser': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/parser': 7.24.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -5505,11 +5492,11 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/parser': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/parser': 7.24.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5551,7 +5538,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -5571,16 +5558,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3)):
+  jest-cli@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      create-jest: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -5590,12 +5577,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3)):
+  jest-config@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3)):
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.7)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -5615,8 +5602,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.14.10
-      ts-node: 10.9.2(@types/node@20.14.10)(typescript@5.3.3)
+      '@types/node': 20.14.11
+      ts-node: 10.9.2(@types/node@20.14.11)(typescript@5.3.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5658,7 +5645,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -5680,7 +5667,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5719,18 +5706,18 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-puppeteer@10.0.1(debug@4.3.5)(puppeteer@22.12.1(typescript@5.3.3))(typescript@5.3.3):
+  jest-puppeteer@10.0.1(debug@4.3.5)(puppeteer@22.13.1(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
       expect-puppeteer: 10.0.0
       jest-environment-puppeteer: 10.0.1(debug@4.3.5)(typescript@5.3.3)
-      puppeteer: 22.12.1(typescript@5.3.3)
+      puppeteer: 22.13.1(typescript@5.3.3)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -5764,7 +5751,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5792,7 +5779,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -5812,15 +5799,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
-      '@babel/types': 7.24.7
+      '@babel/core': 7.24.9
+      '@babel/generator': 7.24.10
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.9)
+      '@babel/types': 7.24.9
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.9)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -5831,14 +5818,14 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
 
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5857,7 +5844,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5866,17 +5853,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3)):
+  jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      jest-cli: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5910,7 +5897,7 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-to-zod@2.3.0: {}
+  json-schema-to-zod@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -5937,7 +5924,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.6.2
+      semver: 7.6.3
 
   jwa@1.4.1:
     dependencies:
@@ -5986,11 +5973,11 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  llm-polyglot@2.0.0(@anthropic-ai/sdk@0.22.0)(openai@4.52.4):
+  llm-polyglot@2.0.0(@anthropic-ai/sdk@0.22.0)(openai@4.52.7):
     dependencies:
       '@anthropic-ai/sdk': 0.22.0
       json-schema: 0.4.0
-      openai: 4.52.4
+      openai: 4.52.7
 
   locate-path@5.0.0:
     dependencies:
@@ -6075,7 +6062,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.2
+      semver: 7.6.3
 
   make-error@1.3.6: {}
 
@@ -6167,9 +6154,9 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  node-addon-api@7.1.0: {}
+  node-addon-api@7.1.1: {}
 
-  node-api-headers@1.1.0: {}
+  node-api-headers@1.2.0: {}
 
   node-domexception@1.0.0: {}
 
@@ -6190,7 +6177,7 @@ snapshots:
       env-var: 7.5.0
       fs-extra: 11.2.0
       log-symbols: 5.1.0
-      node-addon-api: 7.1.0
+      node-addon-api: 7.1.1
       octokit: 3.2.1
       ora: 7.0.1
       simple-git: 3.25.0
@@ -6202,7 +6189,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  node-releases@2.0.14: {}
+  node-releases@2.0.17: {}
 
   normalize-path@3.0.0: {}
 
@@ -6244,9 +6231,9 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@4.52.4:
+  openai@4.52.7:
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.41
       '@types/node-fetch': 2.6.11
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -6408,10 +6395,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@22.12.1:
+  puppeteer-core@22.13.1:
     dependencies:
-      '@puppeteer/browsers': 2.2.3
-      chromium-bidi: 0.5.24(devtools-protocol@0.0.1299070)
+      '@puppeteer/browsers': 2.2.4
+      chromium-bidi: 0.6.1(devtools-protocol@0.0.1299070)
       debug: 4.3.5
       devtools-protocol: 0.0.1299070
       ws: 8.18.0
@@ -6420,65 +6407,65 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer-extra-plugin-stealth@2.11.2(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))):
+  puppeteer-extra-plugin-stealth@2.11.2(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))):
     dependencies:
       debug: 4.3.5
-      puppeteer-extra-plugin: 3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)))
-      puppeteer-extra-plugin-user-preferences: 2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)))
+      puppeteer-extra-plugin: 3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)))
+      puppeteer-extra-plugin-user-preferences: 2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)))
     optionalDependencies:
-      puppeteer-extra: 3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))
+      puppeteer-extra: 3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra-plugin-user-data-dir@2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))):
+  puppeteer-extra-plugin-user-data-dir@2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))):
     dependencies:
       debug: 4.3.5
       fs-extra: 10.1.0
-      puppeteer-extra-plugin: 3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)))
+      puppeteer-extra-plugin: 3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)))
       rimraf: 3.0.2
     optionalDependencies:
-      puppeteer-extra: 3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))
+      puppeteer-extra: 3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra-plugin-user-preferences@2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))):
+  puppeteer-extra-plugin-user-preferences@2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))):
     dependencies:
       debug: 4.3.5
       deepmerge: 4.3.1
-      puppeteer-extra-plugin: 3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)))
-      puppeteer-extra-plugin-user-data-dir: 2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)))
+      puppeteer-extra-plugin: 3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)))
+      puppeteer-extra-plugin-user-data-dir: 2.4.1(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)))
     optionalDependencies:
-      puppeteer-extra: 3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))
+      puppeteer-extra: 3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra-plugin@3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))):
+  puppeteer-extra-plugin@3.2.3(puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.5
       merge-deep: 3.0.3
     optionalDependencies:
-      puppeteer-extra: 3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3))
+      puppeteer-extra: 3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer-extra@3.3.6(puppeteer-core@22.12.1)(puppeteer@22.12.1(typescript@5.3.3)):
+  puppeteer-extra@3.3.6(puppeteer-core@22.13.1)(puppeteer@22.13.1(typescript@5.3.3)):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.5
       deepmerge: 4.3.1
     optionalDependencies:
-      puppeteer: 22.12.1(typescript@5.3.3)
-      puppeteer-core: 22.12.1
+      puppeteer: 22.13.1(typescript@5.3.3)
+      puppeteer-core: 22.13.1
     transitivePeerDependencies:
       - supports-color
 
-  puppeteer@22.12.1(typescript@5.3.3):
+  puppeteer@22.13.1(typescript@5.3.3):
     dependencies:
-      '@puppeteer/browsers': 2.2.3
+      '@puppeteer/browsers': 2.2.4
       cosmiconfig: 9.0.0(typescript@5.3.3)
       devtools-protocol: 0.0.1299070
-      puppeteer-core: 22.12.1
+      puppeteer-core: 22.13.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6533,7 +6520,7 @@ snapshots:
 
   resolve@1.22.8:
     dependencies:
-      is-core-module: 2.14.0
+      is-core-module: 2.15.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -6567,10 +6554,10 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  schema-stream@3.1.0(zod@3.22.4):
+  schema-stream@3.1.0(zod@3.23.8):
     dependencies:
       ramda: 0.29.1
-      zod: 3.22.4
+      zod: 3.23.8
 
   semver@6.3.1: {}
 
@@ -6578,11 +6565,7 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.6.0:
-    dependencies:
-      lru-cache: 6.0.0
-
-  semver@7.6.2: {}
+  semver@7.6.3: {}
 
   set-blocking@2.0.0: {}
 
@@ -6759,7 +6742,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tar-fs@3.0.5:
+  tar-fs@3.0.6:
     dependencies:
       pump: 3.0.0
       tar-stream: 3.1.7
@@ -6812,32 +6795,33 @@ snapshots:
     dependencies:
       typescript: 5.3.3
 
-  ts-jest@29.2.0(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3)))(typescript@5.3.3):
+  ts-jest@29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3)))(typescript@5.3.3):
     dependencies:
       bs-logger: 0.2.6
+      ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3))
+      jest: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.6.3
       typescript: 5.3.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.7)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
 
-  ts-node@10.9.2(@types/node@20.14.10)(typescript@5.3.3):
+  ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.10
+      '@types/node': 20.14.11
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3
@@ -6871,17 +6855,17 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@4.21.0: {}
+  type-fest@4.22.1: {}
 
-  typedoc-plugin-markdown@4.1.2(typedoc@0.26.3(typescript@5.3.3)):
+  typedoc-plugin-markdown@4.2.1(typedoc@0.26.4(typescript@5.3.3)):
     dependencies:
-      typedoc: 0.26.3(typescript@5.3.3)
+      typedoc: 0.26.4(typescript@5.3.3)
 
-  typedoc-plugin-zod@1.2.0(typedoc@0.26.3(typescript@5.3.3)):
+  typedoc-plugin-zod@1.2.0(typedoc@0.26.4(typescript@5.3.3)):
     dependencies:
-      typedoc: 0.26.3(typescript@5.3.3)
+      typedoc: 0.26.4(typescript@5.3.3)
 
-  typedoc@0.26.3(typescript@5.3.3):
+  typedoc@0.26.4(typescript@5.3.3):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0
@@ -6890,11 +6874,11 @@ snapshots:
       typescript: 5.3.3
       yaml: 2.4.5
 
-  typescript-eslint@7.16.0(eslint@8.57.0)(typescript@5.3.3):
+  typescript-eslint@7.16.1(eslint@8.57.0)(typescript@5.3.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.16.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 7.16.0(eslint@8.57.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 7.16.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.3.3
@@ -7040,21 +7024,19 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-stream@1.0.3(openai@4.52.4)(zod@3.22.4):
+  zod-stream@1.0.3(openai@4.52.7)(zod@3.23.8):
     dependencies:
-      openai: 4.52.4
-      schema-stream: 3.1.0(zod@3.22.4)
-      zod: 3.22.4
-      zod-to-json-schema: 3.23.1(zod@3.22.4)
+      openai: 4.52.7
+      schema-stream: 3.1.0(zod@3.23.8)
+      zod: 3.23.8
+      zod-to-json-schema: 3.23.1(zod@3.23.8)
 
-  zod-to-json-schema@3.23.1(zod@3.22.4):
+  zod-to-json-schema@3.23.1(zod@3.23.8):
     dependencies:
-      zod: 3.22.4
+      zod: 3.23.8
 
-  zod-validation-error@2.1.0(zod@3.22.4):
+  zod-validation-error@2.1.0(zod@3.23.8):
     dependencies:
-      zod: 3.22.4
-
-  zod@3.22.4: {}
+      zod: 3.23.8
 
   zod@3.23.8: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: ^0.2.1
         version: 0.2.2(hono@4.4.12)
       '@hono/zod-openapi':
-        specifier: ^0.9.8
-        version: 0.9.10(hono@4.4.12)(zod@3.23.8)
+        specifier: ^0.15.0
+        version: 0.15.0(hono@4.4.12)(zod@3.22.4)
       '@hono/zod-validator':
         specifier: ^0.2.0
-        version: 0.2.2(hono@4.4.12)(zod@3.23.8)
+        version: 0.2.2(hono@4.4.12)(zod@3.22.4)
       '@instructor-ai/instructor':
         specifier: ^1.5.0
-        version: 1.5.0(openai@4.52.4)(zod@3.23.8)
+        version: 1.5.0(openai@4.52.4)(zod@3.22.4)
       '@types/inquirer':
         specifier: ^9.0.7
         version: 9.0.7
@@ -90,8 +90,8 @@ importers:
         specifier: ~5.3.3
         version: 5.3.3
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: 3.22.4
+        version: 3.22.4
     devDependencies:
       '@eslint/js':
         specifier: ^8.56.0
@@ -152,7 +152,7 @@ importers:
         version: 17.7.2
       zod-to-json-schema:
         specifier: ^3.23.0
-        version: 3.23.1(zod@3.23.8)
+        version: 3.23.1(zod@3.22.4)
 
 packages:
 
@@ -163,8 +163,8 @@ packages:
   '@anthropic-ai/sdk@0.22.0':
     resolution: {integrity: sha512-dv4BCC6FZJw3w66WNLsHlUFjhu19fS1L/5jMPApwhZLa/Oy1j0A2i3RypmDtHEPp4Wwg3aZkSHksp7VzYWjzmw==}
 
-  '@asteasolutions/zod-to-openapi@5.5.0':
-    resolution: {integrity: sha512-d5HwrvM6dOKr3XdeF+DmashGvfEc+1oiEfbscugsiwSTrFtuMa7ETpW9sTNnVgn+hJaz+PRxPQUYD7q9/5dUig==}
+  '@asteasolutions/zod-to-openapi@7.1.1':
+    resolution: {integrity: sha512-lF0d1gAc0lYLO9/BAGivwTwE2Sh9h6CHuDcbk5KnGBfIuAsAkDC+Fdat4dkQY3CS/zUWKHRmFEma0B7X132Ymw==}
     peerDependencies:
       zod: ^3.20.2
 
@@ -510,18 +510,12 @@ packages:
     peerDependencies:
       hono: '*'
 
-  '@hono/zod-openapi@0.9.10':
-    resolution: {integrity: sha512-v/b/z0qPxDo952gjRyhJ0n9ifbPoIluR2KmXDL20np0hj99+XvakoIHK5/T/3+hUmXlTj1Kn3TiGsSV6hwZesg==}
+  '@hono/zod-openapi@0.15.0':
+    resolution: {integrity: sha512-NdCoF3AyM4+TW3PM5c2fFI7Sf4hPYBH0ywkN5BA88w9SepSK08P66Qp3QFh2HVYccxxwtLbgFTE0MMMCfvtCrw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      hono: '>=3.11.3'
+      hono: '>=4.3.6'
       zod: 3.*
-
-  '@hono/zod-validator@0.2.1':
-    resolution: {integrity: sha512-HFoxln7Q6JsE64qz2WBS28SD33UB2alp3aRKmcWnNLDzEL1BLsWfbdX6e1HIiUprHYTIXf5y7ax8eYidKUwyaA==}
-    peerDependencies:
-      hono: '>=3.9.0'
-      zod: ^3.19.1
 
   '@hono/zod-validator@0.2.2':
     resolution: {integrity: sha512-dSDxaPV70Py8wuIU2QNpoVEIOSzSXZ/6/B/h4xA7eOMz7+AarKTSGV8E6QwrdcCbBLkpqfJ4Q2TmBO0eP1tCBQ==}
@@ -3386,6 +3380,9 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
@@ -3409,10 +3406,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@asteasolutions/zod-to-openapi@5.5.0(zod@3.23.8)':
+  '@asteasolutions/zod-to-openapi@7.1.1(zod@3.22.4)':
     dependencies:
       openapi3-ts: 4.3.3
-      zod: 3.23.8
+      zod: 3.22.4
 
   '@babel/code-frame@7.24.7':
     dependencies:
@@ -3729,22 +3726,17 @@ snapshots:
     dependencies:
       hono: 4.4.12
 
-  '@hono/zod-openapi@0.9.10(hono@4.4.12)(zod@3.23.8)':
+  '@hono/zod-openapi@0.15.0(hono@4.4.12)(zod@3.22.4)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 5.5.0(zod@3.23.8)
-      '@hono/zod-validator': 0.2.1(hono@4.4.12)(zod@3.23.8)
+      '@asteasolutions/zod-to-openapi': 7.1.1(zod@3.22.4)
+      '@hono/zod-validator': 0.2.2(hono@4.4.12)(zod@3.22.4)
       hono: 4.4.12
-      zod: 3.23.8
+      zod: 3.22.4
 
-  '@hono/zod-validator@0.2.1(hono@4.4.12)(zod@3.23.8)':
+  '@hono/zod-validator@0.2.2(hono@4.4.12)(zod@3.22.4)':
     dependencies:
       hono: 4.4.12
-      zod: 3.23.8
-
-  '@hono/zod-validator@0.2.2(hono@4.4.12)(zod@3.23.8)':
-    dependencies:
-      hono: 4.4.12
-      zod: 3.23.8
+      zod: 3.22.4
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -3758,12 +3750,12 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@instructor-ai/instructor@1.5.0(openai@4.52.4)(zod@3.23.8)':
+  '@instructor-ai/instructor@1.5.0(openai@4.52.4)(zod@3.22.4)':
     dependencies:
       openai: 4.52.4
-      zod: 3.23.8
-      zod-stream: 1.0.3(openai@4.52.4)(zod@3.23.8)
-      zod-validation-error: 2.1.0(zod@3.23.8)
+      zod: 3.22.4
+      zod-stream: 1.0.3(openai@4.52.4)(zod@3.22.4)
+      zod-validation-error: 2.1.0(zod@3.22.4)
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -6575,10 +6567,10 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  schema-stream@3.1.0(zod@3.23.8):
+  schema-stream@3.1.0(zod@3.22.4):
     dependencies:
       ramda: 0.29.1
-      zod: 3.23.8
+      zod: 3.22.4
 
   semver@6.3.1: {}
 
@@ -7048,19 +7040,21 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-stream@1.0.3(openai@4.52.4)(zod@3.23.8):
+  zod-stream@1.0.3(openai@4.52.4)(zod@3.22.4):
     dependencies:
       openai: 4.52.4
-      schema-stream: 3.1.0(zod@3.23.8)
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.1(zod@3.23.8)
+      schema-stream: 3.1.0(zod@3.22.4)
+      zod: 3.22.4
+      zod-to-json-schema: 3.23.1(zod@3.22.4)
 
-  zod-to-json-schema@3.23.1(zod@3.23.8):
+  zod-to-json-schema@3.23.1(zod@3.22.4):
     dependencies:
-      zod: 3.23.8
+      zod: 3.22.4
 
-  zod-validation-error@2.1.0(zod@3.23.8):
+  zod-validation-error@2.1.0(zod@3.22.4):
     dependencies:
-      zod: 3.23.8
+      zod: 3.22.4
+
+  zod@3.22.4: {}
 
   zod@3.23.8: {}

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 import {
   ModelResponseSchema,
   BrowserActionSchemaArray,

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import {
   ModelResponseSchema,
   BrowserActionSchemaArray,
@@ -39,7 +39,7 @@ export class Agent {
         const { agentApiKey, agentProvider, agentModel } = nolitarc();
         const savedAgentArgs = completionApiBuilder(
           { provider: agentProvider, apiKey: agentApiKey },
-          { model: agentModel, objectMode: "TOOLS" }
+          { model: agentModel, objectMode: "TOOLS" },
         );
         this.client = savedAgentArgs.client;
         this.objectGeneratorOptions = {
@@ -65,7 +65,7 @@ export class Agent {
   prompt(
     currentState: ObjectiveState,
     memories: Memory[],
-    config?: { inventory?: Inventory; systemPrompt?: string }
+    config?: { inventory?: Inventory; systemPrompt?: string },
   ): ChatRequestMessage[] {
     const userPrompt = `
     ${config?.inventory ? `Use the following information to achieve your objective as needed: ${config?.inventory.toString()}` : ""}
@@ -91,7 +91,7 @@ export class Agent {
   async generateResponseType<T extends z.ZodObject<any>>(
     currentState: ObjectiveState,
     memories: Memory,
-    responseSchema: T
+    responseSchema: T,
   ): Promise<z.infer<T>> {
     const messages: ChatRequestMessage[] = [
       {
@@ -101,7 +101,7 @@ export class Agent {
         Please generate the objectiveComplete response for the current state: ${JSON.stringify(
           {
             objectiveState: currentState,
-          }
+          },
         )}. You may cannot issue commands. All the information you need is in the the current state.`,
       },
     ];
@@ -122,7 +122,7 @@ export class Agent {
       inventory?: Inventory;
       systemPrompt?: string;
       maxAttempts?: number;
-    }
+    },
   ) {
     const maxAttempts = config?.maxAttempts || 5;
     const modifyActionsPrompt = `
@@ -139,7 +139,7 @@ export class Agent {
     });
 
     const commandSchema = generateSchema(
-      memory.actionStep.command! as SchemaElement[]
+      memory.actionStep.command! as SchemaElement[],
     );
 
     let safeParseResultSuccess = false;
@@ -164,8 +164,8 @@ export class Agent {
         debug.log("Invalid response type. Retrying...");
         response = await response.respond(
           `Invalid response type. Error messages: ${JSON.stringify(
-            safeParseResult
-          )}`
+            safeParseResult,
+          )}`,
         );
         safeParseResult = commandSchema.safeParse(response.command);
         safeParseResultSuccess = safeParseResult.success;
@@ -184,7 +184,7 @@ export class Agent {
       startingDelay: 1000, // Initial delay in milliseconds
       timeMultiple: 2, // Multiplier for the delay
       maxDelay: 10000, // Maximum delay
-    }
+    },
   ) {
     const response = await generateObject(this.client, prompt, {
       schema: schema,
@@ -199,7 +199,7 @@ export class Agent {
   async call<T extends z.ZodSchema<any>>(
     prompt: ChatRequestMessage[],
     responseSchema: T,
-    opts?: { autoSlice?: boolean }
+    opts?: { autoSlice?: boolean },
   ): Promise<T> {
     const response = await generateObject(this.client, prompt, {
       schema: responseSchema,
@@ -232,7 +232,7 @@ export class Agent {
       startingDelay: 1000, // Initial delay in milliseconds
       timeMultiple: 2, // Multiplier for the delay
       maxDelay: 10000, // Maximum delay
-    }
+    },
   ) {
     const chatResponse = await generateObject(this.client, prompt, {
       ...this.objectGeneratorOptions,
@@ -264,7 +264,7 @@ export class Agent {
       startingDelay: 1000, // Initial delay in milliseconds
       timeMultiple: 2, // Multiplier for the delay
       maxDelay: 10000, // Maximum delay
-    }
+    },
   ): Promise<z.infer<T>> {
     const chatResponse = await this.call(prompt, responseSchema, opts);
     return responseSchema.parse(chatResponse);
@@ -295,7 +295,7 @@ export function makeAgent(
   prodiverOpts?: { provider: string; apiKey: string },
   modelConfig?: Partial<ModelConfig>,
   customProvider?: { path: string },
-  opts?: { systemPrompt?: string }
+  opts?: { systemPrompt?: string },
 ) {
   if (!prodiverOpts) {
     const { agentApiKey, agentProvider, agentModel } = nolitarc();
@@ -311,7 +311,7 @@ export function makeAgent(
   const chatApi = completionApiBuilder(
     prodiverOpts,
     modelConfig,
-    customProvider
+    customProvider,
   );
 
   if (!chatApi) {
@@ -328,11 +328,11 @@ export function defaultAgent() {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     throw new Error(
-      "You must set OPENAI_API_KEY in your environment to use the default agent."
+      "You must set OPENAI_API_KEY in your environment to use the default agent.",
     );
   }
   return makeAgent(
     { provider: "openai", apiKey },
-    { model: "gpt-4", objectMode: "TOOLS" }
+    { model: "gpt-4", objectMode: "TOOLS" },
   );
 }

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 import {
   ModelResponseSchema,
   BrowserActionSchemaArray,

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 import {
   ModelResponseSchema,
   BrowserActionSchemaArray,

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -1,6 +1,9 @@
 import { createLLMClient } from "llm-polyglot";
 
-import { ObjectGeneratorOptions, DefaultObjectGeneratorOptions } from "./generators";
+import {
+  ObjectGeneratorOptions,
+  DefaultObjectGeneratorOptions,
+} from "./generators";
 
 export const CompletionDefaultRetries = 3;
 export const CompletionDefaultTimeout = 300_000;
@@ -13,16 +16,19 @@ export type AgentConfig = {
   apiKey: string;
 };
 
-export type ModelConfig = DefaultObjectGeneratorOptions & Omit<ObjectGeneratorOptions, keyof DefaultObjectGeneratorOptions> & { systemPrompt?: string };
+export type ModelConfig = DefaultObjectGeneratorOptions &
+  Omit<ObjectGeneratorOptions, keyof DefaultObjectGeneratorOptions> & {
+    systemPrompt?: string;
+  };
 
 export function completionApiBuilder(
   prodiverOpts: { provider: string; apiKey: string },
   modelConfig: Partial<ModelConfig> = {},
-  customProvider?: { path: string }
+  customProvider?: { path: string },
 ): AgentConfig & ModelConfig {
   const defaultConfig: ModelConfig = {
     objectMode: "TOOLS",
-    model: "gpt-4"
+    model: "gpt-4",
   };
   const finalConfig: ModelConfig = { ...defaultConfig, ...modelConfig };
   const provider = prodiverOpts.provider.toLowerCase();

--- a/src/agent/generators/generateObject.ts
+++ b/src/agent/generators/generateObject.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 // import { LlamaModel } from "node-llama-cpp";
 // import { generateObjectLocal } from "./generateObjectLocal";
 

--- a/src/agent/generators/generateObject.ts
+++ b/src/agent/generators/generateObject.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 // import { LlamaModel } from "node-llama-cpp";
 // import { generateObjectLocal } from "./generateObjectLocal";
 
@@ -27,7 +27,7 @@ export async function generateObject<T extends z.ZodSchema<any>>(
   options: ObjectGeneratorOptions & {
     schema: T;
     name: string;
-  }
+  },
 ) {
   switch (client) {
     // case client instanceof LlamaModel:

--- a/src/agent/generators/generateObject.ts
+++ b/src/agent/generators/generateObject.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 // import { LlamaModel } from "node-llama-cpp";
 // import { generateObjectLocal } from "./generateObjectLocal";
 

--- a/src/agent/generators/generateObject.ts
+++ b/src/agent/generators/generateObject.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 // import { LlamaModel } from "node-llama-cpp";
 // import { generateObjectLocal } from "./generateObjectLocal";
 

--- a/src/agent/generators/generateObjectLocal.ts
+++ b/src/agent/generators/generateObjectLocal.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import {
   LlamaModel,
   LlamaJsonSchemaGrammar,
@@ -30,7 +30,7 @@ export async function generateObjectLocal<T extends z.ZodSchema<any>>(
   options: ObjectGeneratorOptions & {
     schema: T;
     name: string;
-  }
+  },
 ) {
   const maxTokens = options.maxTokens || 1000;
   const temperature = options.temperature || 0;

--- a/src/agent/generators/generateObjectLocal.ts
+++ b/src/agent/generators/generateObjectLocal.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 import {
   LlamaModel,
   LlamaJsonSchemaGrammar,

--- a/src/agent/generators/generateObjectLocal.ts
+++ b/src/agent/generators/generateObjectLocal.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 import {
   LlamaModel,
   LlamaJsonSchemaGrammar,

--- a/src/agent/generators/generateObjectLocal.ts
+++ b/src/agent/generators/generateObjectLocal.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 import {
   LlamaModel,
   LlamaJsonSchemaGrammar,

--- a/src/agent/generators/generateObjectProvider.ts
+++ b/src/agent/generators/generateObjectProvider.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 import Instructor from "@instructor-ai/instructor";
 
 import { ChatRequestMessage } from "../messages";

--- a/src/agent/generators/generateObjectProvider.ts
+++ b/src/agent/generators/generateObjectProvider.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import Instructor from "@instructor-ai/instructor";
 
 import { ChatRequestMessage } from "../messages";
@@ -24,7 +24,7 @@ export async function generateObjectProvider<T extends z.ZodSchema<any>>(
   options: ObjectGeneratorOptions & {
     schema: T;
     name: string;
-  }
+  },
 ) {
   const instructor = Instructor<typeof client>({
     client,

--- a/src/agent/generators/generateObjectProvider.ts
+++ b/src/agent/generators/generateObjectProvider.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 import Instructor from "@instructor-ai/instructor";
 
 import { ChatRequestMessage } from "../messages";

--- a/src/agent/generators/generateObjectProvider.ts
+++ b/src/agent/generators/generateObjectProvider.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 import Instructor from "@instructor-ai/instructor";
 
 import { ChatRequestMessage } from "../messages";

--- a/src/agent/generators/index.ts
+++ b/src/agent/generators/index.ts
@@ -1,4 +1,8 @@
 import { ObjectGeneratorOptions, DefaultObjectGeneratorOptions } from "./types";
 import { generateObject } from "./generateObject";
 
-export { ObjectGeneratorOptions, DefaultObjectGeneratorOptions, generateObject };
+export {
+  ObjectGeneratorOptions,
+  DefaultObjectGeneratorOptions,
+  generateObject,
+};

--- a/src/agent/generators/types.ts
+++ b/src/agent/generators/types.ts
@@ -29,5 +29,5 @@ export type ObjectGeneratorOptions = {
 };
 
 export type DefaultObjectGeneratorOptions = {
-  objectMode: 'TOOLS';
+  objectMode: "TOOLS";
 };

--- a/src/agent/messages.ts
+++ b/src/agent/messages.ts
@@ -73,7 +73,7 @@ export type AgentMessageConfig = {
  * @returns {ChatRequestMessage[]} - The messages to send to the model
  */
 export function handleConfigMessages(
-  config: AgentMessageConfig
+  config: AgentMessageConfig,
 ): ChatRequestMessage[] {
   const messages: ChatRequestMessage[] = [];
 
@@ -98,7 +98,7 @@ export function handleConfigMessages(
  */
 export function commandPrompt(
   currentState: ObjectiveState,
-  config?: AgentMessageConfig
+  config?: AgentMessageConfig,
 ): ChatRequestMessage[] {
   const messages = handleConfigMessages(config || {});
   const memories = config?.memories;
@@ -137,7 +137,7 @@ export function commandPrompt(
  */
 export function getPrompt(
   state: string,
-  config?: AgentMessageConfig
+  config?: AgentMessageConfig,
 ): ChatRequestMessage[] {
   const mode = config?.mode || "aria";
   const messages = handleConfigMessages(config || {});

--- a/src/agent/schemaGenerators.ts
+++ b/src/agent/schemaGenerators.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 export interface SchemaElement {
   kind: string;
   index: number;

--- a/src/agent/schemaGenerators.ts
+++ b/src/agent/schemaGenerators.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 export interface SchemaElement {
   kind: string;
   index: number;

--- a/src/agent/schemaGenerators.ts
+++ b/src/agent/schemaGenerators.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 export interface SchemaElement {
   kind: string;
   index: number;

--- a/src/agent/schemaGenerators.ts
+++ b/src/agent/schemaGenerators.ts
@@ -1,4 +1,4 @@
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 export interface SchemaElement {
   kind: string;
   index: number;

--- a/src/agentBrowser.ts
+++ b/src/agentBrowser.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "./lib/zod";
 import { Browser, Page } from "./browser";
 import { Logger, generateUUID } from "./utils";
 

--- a/src/agentBrowser.ts
+++ b/src/agentBrowser.ts
@@ -1,4 +1,4 @@
-import { z } from "./lib/zod";
+import { z } from "@hono/zod-openapi";
 import { Browser, Page } from "./browser";
 import { Logger, generateUUID } from "./utils";
 

--- a/src/agentBrowser.ts
+++ b/src/agentBrowser.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 import { Browser, Page } from "./browser";
 import { Logger, generateUUID } from "./utils";
 

--- a/src/agentBrowser.ts
+++ b/src/agentBrowser.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import { Browser, Page } from "./browser";
 import { Logger, generateUUID } from "./utils";
 
@@ -53,7 +53,7 @@ export class AgentBrowser {
     this.config =
       agentBrowserArgs.behaviorConfig ??
       BrowserBehaviorConfig.parse(
-        {} as any // for zod optionals
+        {} as any, // for zod optionals
       );
     this.inventory = agentBrowserArgs.inventory;
 
@@ -72,10 +72,10 @@ export class AgentBrowser {
     // call this so the browser's internal page state is updated
     const state = await page.state(
       memory.objectiveState.objective,
-      this.objectiveProgress
+      this.objectiveProgress,
     );
     const hasText = memory.actionStep.command?.some(
-      (action: any) => action.kind === "Type"
+      (action: any) => action.kind === "Type",
     );
     let description = "";
     // we should relax this condition in the future
@@ -108,18 +108,18 @@ export class AgentBrowser {
   }
 
   async followPath<
-    TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete
+    TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete,
   >(
     memorySequenceId: string,
     page: Page,
     browserObjective: BrowserObjective,
     responseSchema: ReturnType<
       typeof ObjectiveCompleteResponse<TObjectiveComplete>
-    >
+    >,
   ) {
     const memoriesBackwards = await fetchMemorySequence(
       memorySequenceId,
-      this.hdrConfig
+      this.hdrConfig,
     );
 
     this.logger.log("Following memory sequence: " + memorySequenceId);
@@ -139,12 +139,12 @@ export class AgentBrowser {
         if (memory.actionStep.objectiveComplete) {
           const state: ObjectiveState = await page.state(
             memory.objectiveState.objective,
-            this.objectiveProgress
+            this.objectiveProgress,
           );
           const step = await this.agent.generateResponseType(
             state,
             memory,
-            responseSchema
+            responseSchema,
           );
           // todo: this is messy because it is not returning the correct type. Need to fix.
           const stepResponse = responseSchema.parse(step.objectiveComplete);
@@ -188,15 +188,15 @@ export class AgentBrowser {
   }
 
   async step<
-    TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete
+    TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete,
   >(
     page: Page,
     currentObjective: string,
-    responseType: ReturnType<typeof ModelResponseSchema<TObjectiveComplete>>
+    responseType: ReturnType<typeof ModelResponseSchema<TObjectiveComplete>>,
   ) {
     const state: ObjectiveState = await page.state(
       currentObjective,
-      this.objectiveProgress
+      this.objectiveProgress,
     );
     const memories = await this.remember(state);
     let config = {};
@@ -211,7 +211,7 @@ export class AgentBrowser {
     }
     this.memorize(
       state,
-      ModelResponseSchema(ObjectiveComplete).parse(response)
+      ModelResponseSchema(ObjectiveComplete).parse(response),
     );
     this.objectiveProgress.push(response.description);
 
@@ -219,10 +219,10 @@ export class AgentBrowser {
   }
 
   async browse<
-    TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete
+    TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete,
   >(
     browserObjective: BrowserObjective,
-    responseType: ReturnType<typeof ModelResponseSchema<TObjectiveComplete>>
+    responseType: ReturnType<typeof ModelResponseSchema<TObjectiveComplete>>,
   ) {
     const { startUrl, objective, maxIterations } =
       BrowserObjective.parse(browserObjective);
@@ -235,7 +235,7 @@ export class AgentBrowser {
 
     const memoryRoute = await findRoute(
       { url: startUrl, objective: objective[0] },
-      this.hdrConfig
+      this.hdrConfig,
     );
 
     if (memoryRoute) {
@@ -252,7 +252,7 @@ export class AgentBrowser {
           if (this.iterationCount > maxIterations) {
             return await this.returnErrorState(
               page,
-              "Maximum number of iterations exceeded"
+              "Maximum number of iterations exceeded",
             );
           }
           const step = await this.step(page, currentObjective, responseType);
@@ -264,7 +264,7 @@ export class AgentBrowser {
 
           if (stepResponse.command) {
             debug.write(
-              "Performing action:" + JSON.stringify(stepResponse.command)
+              "Performing action:" + JSON.stringify(stepResponse.command),
             );
             page.performManyActions(stepResponse.command as BrowserAction[], {
               inventory: this.inventory,

--- a/src/bin/commands/create.ts
+++ b/src/bin/commands/create.ts
@@ -22,7 +22,7 @@ module.exports = {
     // validate the name to ensure it's npm compatible
     if (!/^[a-z0-9-@]+$/.test(name)) {
       return toolbox.print.error(
-        "Invalid folder name. Use @, lowercase, and dashes only."
+        "Invalid folder name. Use @, lowercase, and dashes only.",
       );
     }
     await simpleGit({
@@ -34,7 +34,7 @@ module.exports = {
     filesystem.remove(`${name}/LICENSE`);
     filesystem.move(
       `${name}/extensions/.inventory.example`,
-      `${name}/extensions/.inventory`
+      `${name}/extensions/.inventory`,
     );
     toolbox.print.success(`Created ${name} project`);
     toolbox.system.run(`cd ${name} && npm install`);
@@ -54,7 +54,7 @@ module.exports = {
       maxConcurrentProcesses: 6,
     }).commit("Initial commit");
     toolbox.print.success(
-      `Your project is ready! Get started in the ${name} directory.`
+      `Your project is ready! Get started in the ${name} directory.`,
     );
   },
 };

--- a/src/bin/commands/serve.ts
+++ b/src/bin/commands/serve.ts
@@ -15,7 +15,7 @@ module.exports = {
     });
     print.success(`Server started on port ${port || 3000}`);
     print.info(
-      `Documentation available at http://localhost:${port || 3000}/doc`
+      `Documentation available at http://localhost:${port || 3000}/doc`,
     );
     print.info("Press Ctrl+C to stop the server.");
     return new Promise<void>((resolve) => {

--- a/src/bin/run.ts
+++ b/src/bin/run.ts
@@ -20,7 +20,7 @@ const loadConfigFile = (filePath: string): any => {
 
 const loadConfigs = (config: string | undefined): any => {
   const commandLineConfig = loadConfigFile(
-    path.resolve(process.cwd(), config || "")
+    path.resolve(process.cwd(), config || ""),
   );
   const homeConfig = loadConfigFile(path.resolve(os.homedir(), ".nolitarc"));
   const mergedConfig = { ...homeConfig, ...commandLineConfig };
@@ -114,7 +114,7 @@ const getConfig = (
   headless: boolean | string | undefined,
   hdrDisable: boolean | string | undefined,
   record: boolean | string | undefined,
-  replay: string | undefined
+  replay: string | undefined,
 ): any => ({
   startUrl: startUrl || mergedConfig.startUrl,
   objective: objective || mergedConfig.objective,
@@ -164,7 +164,7 @@ export const run = async (toolbox: GluegunToolbox) => {
     headless,
     hdrDisable,
     record,
-    replay
+    replay,
   );
   // default true
   resolvedConfig.headless =
@@ -183,7 +183,7 @@ export const run = async (toolbox: GluegunToolbox) => {
 
   if (!resolvedConfig.hdrApiKey && !resolvedConfig.hdrDisable) {
     toolbox.print.muted(
-      "No API key for Memory Index provided. Use `npx nolita auth` to authenticate or suppress this message with --hdrDisable."
+      "No API key for Memory Index provided. Use `npx nolita auth` to authenticate or suppress this message with --hdrDisable.",
     );
   }
 
@@ -214,7 +214,7 @@ export const run = async (toolbox: GluegunToolbox) => {
 
   if (!resolvedConfig.agentProvider) {
     return toolbox.print.error(
-      "No model config found. Please use `npx nolita auth` to set one."
+      "No model config found. Please use `npx nolita auth` to set one.",
     );
   }
 
@@ -245,7 +245,7 @@ export const run = async (toolbox: GluegunToolbox) => {
               result: parsedInput?.objectiveComplete?.result,
               record: page.pageId,
             })
-          : parsedInput?.objectiveComplete?.result
+          : parsedInput?.objectiveComplete?.result,
       );
     } else if (parsedInput?.["objectiveFailed"]) {
       spinner.fail(parsedInput?.objectiveFailed?.result);
@@ -262,7 +262,7 @@ export const run = async (toolbox: GluegunToolbox) => {
 
   if (!chatApi) {
     throw new Error(
-      `Failed to create chat api for ${providerOptions.provider}`
+      `Failed to create chat api for ${providerOptions.provider}`,
     );
   }
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -55,7 +55,7 @@ export class Browser {
       endpoint?: string;
       inventory?: Inventory;
       disableMemory?: boolean;
-    }
+    },
   ) {
     const { hdrApiKey } = nolitarc();
     this.disableMemory = opts?.disableMemory || false;
@@ -98,17 +98,17 @@ export class Browser {
       endpoint?: string;
       inventory?: Inventory;
       disableMemory?: boolean;
-    }
+    },
   ): Promise<Browser> {
     const browser = new Browser(
       await browserContext(
         headless,
         opts?.browserWSEndpoint,
-        opts?.browserLaunchArgs
+        opts?.browserLaunchArgs,
       ),
       agent,
       logger,
-      opts
+      opts,
     );
 
     return browser;
@@ -166,7 +166,7 @@ export class Browser {
             return;
           }
         }
-      })
+      }),
     );
 
     await this.browser.close();

--- a/src/browser/browserUtils.ts
+++ b/src/browser/browserUtils.ts
@@ -39,7 +39,7 @@ export const getChromePath = (): string | undefined => {
 export const browserContext = async (
   headless: boolean,
   browserWSEndpoint?: string,
-  browserLaunchArgs?: string[]
+  browserLaunchArgs?: string[],
 ) => {
   let browser: PuppeteerBrowser;
   if (browserWSEndpoint) {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -10,7 +10,7 @@ import {
 // @ts-expect-error We are using undocumented puppeteer APIs
 import { MAIN_WORLD } from "puppeteer";
 
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 import Turndown from "turndown";
 
 import {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -10,7 +10,7 @@ import {
 // @ts-expect-error We are using undocumented puppeteer APIs
 import { MAIN_WORLD } from "puppeteer";
 
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import Turndown from "turndown";
 
 import {
@@ -74,7 +74,7 @@ export class Page {
       apiKey?: string;
       endpoint?: string;
       disableMemory?: boolean;
-    }
+    },
   ) {
     this.page = page;
     this.agent = agent;
@@ -111,7 +111,7 @@ export class Page {
   async setViewport(
     width: number,
     height: number,
-    deviceScaleFactor: number = 1
+    deviceScaleFactor: number = 1,
   ) {
     this.page.setViewport({ width, height, deviceScaleFactor });
   }
@@ -174,7 +174,7 @@ export class Page {
           pageId: this.pageId,
           timestamp: Date.now(),
           message: msg,
-        })
+        }),
       );
     }
   }
@@ -216,7 +216,7 @@ export class Page {
     client: CDPSession,
     element: ElementHandle<Node>,
     accessibleName?: string,
-    role?: string
+    role?: string,
   ): Promise<Protocol.Accessibility.AXNode[]> {
     const { nodes } = await client.send("Accessibility.queryAXTree", {
       objectId: element.remoteObject().objectId,
@@ -226,7 +226,7 @@ export class Page {
     const filteredNodes: Protocol.Accessibility.AXNode[] = nodes.filter(
       (node: Protocol.Accessibility.AXNode) => {
         return !node.role || node.role.value !== "StaticText"; /// hmmm maybe we should remove?
-      }
+      },
     );
     return filteredNodes;
   }
@@ -246,7 +246,7 @@ export class Page {
     const res = await this.queryAXTree(client, body!, name, role);
     if (!res[0] || !res[0].backendDOMNodeId) {
       throw new Error(
-        `Could not find element with role ${res[0].role} and name ${res[0].name}`
+        `Could not find element with role ${res[0].role} and name ${res[0].name}`,
       );
     }
     const backendNodeId = res[0].backendDOMNodeId;
@@ -255,12 +255,12 @@ export class Page {
       .mainFrame()
       // @ts-expect-error this is black magic referring to the execution context
       .worlds[MAIN_WORLD].adoptBackendNode(
-        backendNodeId
+        backendNodeId,
       )) as ElementHandle<Element>;
 
     if (!ret) {
       throw new Error(
-        `Could not find element by backendNodeId with role ${role} and name ${name}`
+        `Could not find element by backendNodeId with role ${role} and name ${name}`,
       );
     }
     return ret;
@@ -318,7 +318,7 @@ export class Page {
    */
   async state(
     objective: string,
-    objectiveProgress?: string[]
+    objectiveProgress?: string[],
   ): Promise<ObjectiveState> {
     const contentJSON = await this.parseContent();
     const content = ObjectiveState.parse({
@@ -350,7 +350,7 @@ export class Page {
    */
   async performAction(
     command: BrowserAction,
-    opts?: { delay?: number; inventory?: Inventory }
+    opts?: { delay?: number; inventory?: Inventory },
   ) {
     const inventory = opts?.inventory ?? this.inventory;
     const delay = opts?.delay ?? 100;
@@ -403,7 +403,7 @@ export class Page {
     } catch (e) {
       this.error = (e as Error).toString();
       debug.error(
-        ` Error ${this.error} on command: ${JSON.stringify(command)}`
+        ` Error ${this.error} on command: ${JSON.stringify(command)}`,
       );
     }
   }
@@ -417,7 +417,7 @@ export class Page {
    */
   async performManyActions(
     commands: BrowserAction[],
-    opts?: { delay?: number; inventory?: Inventory }
+    opts?: { delay?: number; inventory?: Inventory },
   ) {
     for (const command of commands) {
       await this.performAction(command, opts);
@@ -434,11 +434,11 @@ export class Page {
    */
   async makePrompt(
     request: string,
-    opts?: { progress?: string[]; agent?: Agent; inventory?: Inventory }
+    opts?: { progress?: string[]; agent?: Agent; inventory?: Inventory },
   ) {
     const state = (await this.state(
       request,
-      opts?.progress ?? this.progress
+      opts?.progress ?? this.progress,
     )) as ObjectiveState;
     const agent = opts?.agent ?? this.agent;
     const memories = this.disableMemory
@@ -471,7 +471,7 @@ export class Page {
       agent?: Agent;
       schema: T;
       inventory?: Inventory;
-    }
+    },
   ): Promise<z.infer<T>> {
     const agent = opts?.agent ?? this.agent;
     const { prompt, state } = await this.makePrompt(request, opts);
@@ -509,7 +509,7 @@ export class Page {
       progress?: string[];
       delay?: number;
       schema?: z.ZodSchema<any>;
-    }
+    },
   ) {
     const schema = z.object({
       command: opts?.schema ?? z.array(BrowserAction).min(1),
@@ -539,7 +539,7 @@ export class Page {
   async get<T extends z.ZodSchema<any>>(
     request: string,
     outputSchema: z.ZodSchema<any> = ObjectiveComplete,
-    opts?: { agent?: Agent; progress?: string[]; mode?: StateType }
+    opts?: { agent?: Agent; progress?: string[]; mode?: StateType },
   ): Promise<z.infer<T>> {
     const agent = opts?.agent ?? this.agent;
     const { prompt } = await this.makePrompt(request, opts);
@@ -580,7 +580,7 @@ export class Page {
       progress?: string[];
       inventory?: Inventory;
       delay?: number;
-    }
+    },
   ) {
     const schema = extendModelResponse(outputSchema);
     const step = await this.generateCommand(objective, {
@@ -634,7 +634,7 @@ export class Page {
       maxTurns: number;
     } = {
       maxTurns: 20,
-    }
+    },
   ) {
     let currentTurn = 0;
     while (currentTurn < opts.maxTurns) {
@@ -672,7 +672,7 @@ export class Page {
       schema?: z.ZodObject<any>;
       agent?: Agent;
       memoryDelay?: number;
-    }
+    },
   ) {
     const { actionStep, objectiveState } = Memory.parse(memory);
 
@@ -708,7 +708,7 @@ export class Page {
       maxTurns?: number;
       inventory?: Inventory;
       schema?: z.ZodObject<any>;
-    }
+    },
   ) {
     const memories = await fetchMemorySequence(memoryId, {
       apiKey: this.apiKey,
@@ -771,11 +771,11 @@ export class Page {
           .map(function (element) {
             const vw = Math.max(
               document.documentElement.clientWidth || 0,
-              window.innerWidth || 0
+              window.innerWidth || 0,
             );
             const vh = Math.max(
               document.documentElement.clientHeight || 0,
-              window.innerHeight || 0
+              window.innerHeight || 0,
             );
 
             const rects = [...element.getClientRects()]
@@ -784,7 +784,7 @@ export class Page {
                 const center_y = bb.top + bb.height / 2;
                 const elAtCenter = document.elementFromPoint(
                   center_x,
-                  center_y
+                  center_y,
                 );
 
                 return elAtCenter === element || element.contains(elAtCenter);
@@ -804,7 +804,7 @@ export class Page {
               });
             const area = rects.reduce(
               (acc, rect) => acc + rect.width * rect.height,
-              0
+              0,
             );
 
             return {
@@ -828,7 +828,7 @@ export class Page {
 
         // Only keep inner clickable items
         items = items.filter(
-          (x) => !items.some((y) => x.element.contains(y.element) && !(x == y))
+          (x) => !items.some((y) => x.element.contains(y.element) && !(x == y)),
         );
 
         items.forEach(function (item, index) {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -10,7 +10,7 @@ import {
 // @ts-expect-error We are using undocumented puppeteer APIs
 import { MAIN_WORLD } from "puppeteer";
 
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 import Turndown from "turndown";
 
 import {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -10,7 +10,7 @@ import {
 // @ts-expect-error We are using undocumented puppeteer APIs
 import { MAIN_WORLD } from "puppeteer";
 
-import { z } from "zod";
+import { z } from "lib/zod"
 import Turndown from "turndown";
 
 import {

--- a/src/collectiveMemory/compareAriaTrees.ts
+++ b/src/collectiveMemory/compareAriaTrees.ts
@@ -32,7 +32,7 @@ export function parseAriaTree(array: any[]): any[] {
 export function updateCommandIndices(
   objectiveStateOld: ObjectiveState,
   objectiveStateNew: ObjectiveState,
-  commands: any[]
+  commands: any[],
 ) {
   const oldAriaTree = parseAriaTree(JSON.parse(objectiveStateOld.ariaTree));
   const newAriaTree = parseAriaTree(JSON.parse(objectiveStateNew.ariaTree));

--- a/src/collectiveMemory/memorize.ts
+++ b/src/collectiveMemory/memorize.ts
@@ -8,7 +8,7 @@ export async function memorize(
   state: ObjectiveState,
   action: ModelResponseType,
   sequenceId: string,
-  collectiveMemoryConfig?: CollectiveMemoryConfig
+  collectiveMemoryConfig?: CollectiveMemoryConfig,
 ) {
   const endpointValue =
     process.env.HDR_ENDPOINT! ??

--- a/src/collectiveMemory/remember.ts
+++ b/src/collectiveMemory/remember.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 import { URL } from "url";
 
 import { ObjectiveState } from "../types/browser";

--- a/src/collectiveMemory/remember.ts
+++ b/src/collectiveMemory/remember.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import { URL } from "url";
 
 import { ObjectiveState } from "../types/browser";
@@ -16,7 +16,7 @@ export type HDRConfig = z.infer<typeof HDRConfig>;
 export async function fetchStateActionPairs(
   state: ObjectiveState,
   requestId: string,
-  opts?: { apiKey?: string; endpoint?: string; limit?: number }
+  opts?: { apiKey?: string; endpoint?: string; limit?: number },
 ): Promise<Memory[]> {
   const endpoint =
     opts?.endpoint ?? process.env.HDR_ENDPOINT ?? "https://api.hdr.is";
@@ -46,7 +46,7 @@ export async function fetchStateActionPairs(
 
   if (!response.ok) {
     throw new Error(
-      `HDR API request failed with status ${response.status} to url ${response.url}`
+      `HDR API request failed with status ${response.status} to url ${response.url}`,
     );
   }
   const data = await response.json();
@@ -59,23 +59,23 @@ export async function fetchStateActionPairs(
     Memory.parse({
       actionStep: m.action,
       objectiveState: m.state,
-    })
+    }),
   ) as Memory[];
 }
 
 export async function remember(
   objectiveState: ObjectiveState,
   requestId: string,
-  opts?: { apiKey?: string; endpoint?: string; limit?: number }
+  opts?: { apiKey?: string; endpoint?: string; limit?: number },
 ): Promise<Memory[]> {
   try {
     const memories = await fetchStateActionPairs(
       objectiveState,
       requestId,
-      opts
+      opts,
     );
     const filteredMemories = memories.filter(
-      (memory) => memory.actionStep.command !== undefined
+      (memory) => memory.actionStep.command !== undefined,
     );
     if (filteredMemories.length === 0) {
       return DEFAULT_STATE_ACTION_PAIRS;
@@ -89,7 +89,7 @@ export async function remember(
 
 export async function fetchMemorySequence(
   sequenceId: string,
-  opts?: { apiKey?: string; endpoint?: string }
+  opts?: { apiKey?: string; endpoint?: string },
 ) {
   const { apiKey, endpoint } = opts
     ? opts
@@ -112,7 +112,7 @@ export async function fetchMemorySequence(
 
   if (!response.ok) {
     throw new Error(
-      `HDR API request failed with status ${response.status} to url ${response.url}`
+      `HDR API request failed with status ${response.status} to url ${response.url}`,
     );
   }
 
@@ -122,13 +122,13 @@ export async function fetchMemorySequence(
     Memory.parse({
       actionStep: m.actionState,
       objectiveState: m.ObjectiveState,
-    })
+    }),
   ) as Memory[];
 }
 
 export async function fetchRoute(
   routeParams: { url: string; objective: string },
-  opts?: { apiKey?: string; endpoint?: string }
+  opts?: { apiKey?: string; endpoint?: string },
 ) {
   const { apiKey, endpoint } = opts!;
 
@@ -149,7 +149,7 @@ export async function fetchRoute(
   if (!response.ok) {
     console.error("Error calling HDR API:", await response.text());
     throw new Error(
-      `HDR API request failed with status ${response.status} to url ${response.url}`
+      `HDR API request failed with status ${response.status} to url ${response.url}`,
     );
   }
 
@@ -160,7 +160,7 @@ export async function fetchRoute(
 
 export async function findRoute(
   routeParams: { url: string; objective: string },
-  opts?: { apiKey?: string; endpoint?: string }
+  opts?: { apiKey?: string; endpoint?: string },
 ): Promise<Memory[] | undefined> {
   const { apiKey, endpoint } = opts
     ? opts

--- a/src/collectiveMemory/remember.ts
+++ b/src/collectiveMemory/remember.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 import { URL } from "url";
 
 import { ObjectiveState } from "../types/browser";

--- a/src/collectiveMemory/remember.ts
+++ b/src/collectiveMemory/remember.ts
@@ -1,4 +1,4 @@
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 import { URL } from "url";
 
 import { ObjectiveState } from "../types/browser";

--- a/src/inventory/inventory.ts
+++ b/src/inventory/inventory.ts
@@ -30,7 +30,7 @@ export class Inventory {
   replaceMask(value: string): string {
     // TODO: maybe look for substrings instead of exact matches
     const found = this.maskedInventory.find(
-      (item) => `${item.value}` === `${value}`
+      (item) => `${item.value}` === `${value}`,
     );
     if (found) {
       return this.inventory.find((item) => item.name === found.name)
@@ -45,7 +45,7 @@ export class Inventory {
     this.inventory.forEach((item, idx) => {
       censoredStr = censoredStr.replace(
         new RegExp(`${item.value}`, "g"),
-        `${this.maskedInventory[idx].value}`
+        `${this.maskedInventory[idx].value}`,
       );
     });
     return censoredStr;

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { extendZodWithOpenApi } from '@hono/zod-openapi';
+
+extendZodWithOpenApi(z);
+
+export { z };

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
-import { extendZodWithOpenApi } from '@hono/zod-openapi';
+import { z } from "zod";
+import { extendZodWithOpenApi } from "@hono/zod-openapi";
 
 extendZodWithOpenApi(z);
 

--- a/src/nolita.ts
+++ b/src/nolita.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { Agent } from "./agent";
 import { makeAgent } from "./agent";

--- a/src/nolita.ts
+++ b/src/nolita.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { Agent } from "./agent";
 import { makeAgent } from "./agent";
@@ -40,7 +40,7 @@ export class Nolita {
       temperature?: number;
       systemPrompt?: string;
       endpoint?: string;
-    }
+    },
   ) {
     this.hdrApiKey = hdrApiKey;
     this.hdrEndpoint = opts?.endpoint ?? this.hdrEndpoint;
@@ -51,7 +51,7 @@ export class Nolita {
       },
       { model: opts?.model ?? "gpt-4", ...opts },
       undefined,
-      { systemPrompt: opts?.systemPrompt }
+      { systemPrompt: opts?.systemPrompt },
     );
   }
 
@@ -73,7 +73,7 @@ export class Nolita {
       objective: string;
       returnSchema: z.ZodObject<any>;
     },
-    opts?: { maxTurns?: number; headless?: boolean; inventory: Inventory }
+    opts?: { maxTurns?: number; headless?: boolean; inventory: Inventory },
   ) {
     const browser = await Browser.launch(
       opts?.headless ?? false,
@@ -83,7 +83,7 @@ export class Nolita {
         apiKey: this.hdrApiKey,
         endpoint: this.hdrEndpoint,
         ...opts,
-      }
+      },
     );
 
     const page = await browser.newPage();

--- a/src/nolita.ts
+++ b/src/nolita.ts
@@ -1,4 +1,4 @@
-import { z } from "./lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { Agent } from "./agent";
 import { makeAgent } from "./agent";

--- a/src/nolita.ts
+++ b/src/nolita.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "./lib/zod";
 
 import { Agent } from "./agent";
 import { makeAgent } from "./agent";

--- a/src/server/browser/close.ts
+++ b/src/server/browser/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "./launch";
 

--- a/src/server/browser/close.ts
+++ b/src/server/browser/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "./launch";
 

--- a/src/server/browser/close.ts
+++ b/src/server/browser/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "./launch";
 

--- a/src/server/browser/close.ts
+++ b/src/server/browser/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "./launch";
 

--- a/src/server/browser/launch.ts
+++ b/src/server/browser/launch.ts
@@ -70,6 +70,7 @@ const route = createRoute({
 export const launchRouter = new OpenAPIHono();
 
 launchRouter.openapi(route, async (c) => {
+  try {
   const {
     agent: agentArgs,
     inventory: inventoryArgs,
@@ -82,37 +83,8 @@ launchRouter.openapi(route, async (c) => {
   const provider = agentArgs?.provider ?? agentProvider;
   const apiKey = agentArgs?.apiKey ?? agentApiKey;
   const model = agentArgs?.model ?? agentModel;
-  if (!provider) {
-    return c.json(
-      {
-        code: 400,
-        message:
-          "No agent provider specified. Please use `npx nolita auth` to set a config or pass it directly.",
-      },
-      400
-    );
-  }
-
-  if (!apiKey) {
-    return c.json(
-      {
-        code: 400,
-        message:
-          "No agent API key specified. Please use `npx nolita auth` to set a config or pass it directly.",
-      },
-      400
-    );
-  }
-
-  if (!model) {
-    return c.json(
-      {
-        code: 400,
-        message:
-          "No agent model specified. Please use `npx nolita auth` to set a config or pass it directly.",
-      },
-      400
-    );
+  if (!provider || !apiKey || !model) {
+    throw new Error("Missing agent configuration. Use `npx nolita auth` to set it.");
   }
 
   const chatApi = completionApiBuilder(
@@ -143,5 +115,8 @@ launchRouter.openapi(route, async (c) => {
 
   const sessionId = generateUUID();
   BROWSERS.set(sessionId, browser);
-  return c.json({ sessionId });
+  return c.json({ sessionId }, 200);
+} catch (e) {
+  return c.json({ code: 400, message: JSON.stringify(e) }, 400);
+}
 });

--- a/src/server/browser/launch.ts
+++ b/src/server/browser/launch.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { Logger, generateUUID } from "../../utils";
 

--- a/src/server/browser/launch.ts
+++ b/src/server/browser/launch.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { Logger, generateUUID } from "../../utils";
 

--- a/src/server/browser/launch.ts
+++ b/src/server/browser/launch.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { Logger, generateUUID } from "../../utils";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@
 import { Hono } from "hono"; // this must be left in for setupServer to work
 import { serve } from "@hono/node-server";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 import { JsonSchema } from "json-schema-to-zod";
 import { swaggerUI } from "@hono/swagger-ui";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@
 import { Hono } from "hono"; // this must be left in for setupServer to work
 import { serve } from "@hono/node-server";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 import { JsonSchema } from "json-schema-to-zod";
 import { swaggerUI } from "@hono/swagger-ui";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@
 import { Hono } from "hono"; // this must be left in for setupServer to work
 import { serve } from "@hono/node-server";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 import { JsonSchema } from "json-schema-to-zod";
 import { swaggerUI } from "@hono/swagger-ui";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@
 import { Hono } from "hono"; // this must be left in for setupServer to work
 import { serve } from "@hono/node-server";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import { JsonSchema } from "json-schema-to-zod";
 import { swaggerUI } from "@hono/swagger-ui";
 
@@ -76,7 +76,7 @@ export const setupServer = () => {
       {
         model: agentModel,
         objectMode: "TOOLS",
-      }
+      },
     );
 
     const agent = new Agent({ modelApi: chatApi });
@@ -124,7 +124,7 @@ export const setupServer = () => {
         objective: browse_config.objective,
         maxIterations: browse_config.maxIterations,
       },
-      ModelResponseSchema(responseType)
+      ModelResponseSchema(responseType),
     );
 
     await agentBrowser.close();
@@ -138,7 +138,7 @@ export const setupServer = () => {
         code: 400,
         message: "No response from the agent",
       },
-      400
+      400,
     );
   });
 

--- a/src/server/pages/browse.ts
+++ b/src/server/pages/browse.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/browse.ts
+++ b/src/server/pages/browse.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";
@@ -91,8 +91,8 @@ browseRouter.openapi(route, async (c) => {
   const inventory = inventoryArgs
     ? new Inventory(
         Object.entries(inventoryArgs).map(
-          ([name, value]) => ({ name, value } as InventoryValue)
-        )
+          ([name, value]) => ({ name, value }) as InventoryValue,
+        ),
       )
     : undefined;
 

--- a/src/server/pages/browse.ts
+++ b/src/server/pages/browse.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/browse.ts
+++ b/src/server/pages/browse.ts
@@ -102,5 +102,5 @@ browseRouter.openapi(route, async (c) => {
     inventory,
   });
 
-  return c.json(result);
+  return c.json(result, 200);
 });

--- a/src/server/pages/browse.ts
+++ b/src/server/pages/browse.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/close.ts
+++ b/src/server/pages/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/close.ts
+++ b/src/server/pages/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/close.ts
+++ b/src/server/pages/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/close.ts
+++ b/src/server/pages/close.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/content.ts
+++ b/src/server/pages/content.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";
@@ -85,6 +85,7 @@ contentRouter.openapi(route, async (c) => {
       pageContent: content,
       type: type,
       url: page.url(),
-    }), 200
+    }),
+    200,
   );
 });

--- a/src/server/pages/content.ts
+++ b/src/server/pages/content.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/content.ts
+++ b/src/server/pages/content.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/content.ts
+++ b/src/server/pages/content.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/content.ts
+++ b/src/server/pages/content.ts
@@ -85,6 +85,6 @@ contentRouter.openapi(route, async (c) => {
       pageContent: content,
       type: type,
       url: page.url(),
-    })
+    }), 200
   );
 });

--- a/src/server/pages/do.ts
+++ b/src/server/pages/do.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";
@@ -70,8 +70,8 @@ doRouter.openapi(route, async (c) => {
   const inventory = inventoryArgs
     ? new Inventory(
         Object.entries(inventoryArgs).map(
-          ([name, value]) => ({ name, value } as InventoryValue)
-        )
+          ([name, value]) => ({ name, value }) as InventoryValue,
+        ),
       )
     : undefined;
 

--- a/src/server/pages/do.ts
+++ b/src/server/pages/do.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/do.ts
+++ b/src/server/pages/do.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/do.ts
+++ b/src/server/pages/do.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/do.ts
+++ b/src/server/pages/do.ts
@@ -77,5 +77,5 @@ doRouter.openapi(route, async (c) => {
 
   await page.do(command, { inventory, delay });
 
-  return c.json(await page.state(command, page.progress));
+  return c.json(await page.state(command, page.progress), 200);
 });

--- a/src/server/pages/get.ts
+++ b/src/server/pages/get.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { JsonSchema } from "json-schema-to-zod";

--- a/src/server/pages/get.ts
+++ b/src/server/pages/get.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { JsonSchema } from "json-schema-to-zod";

--- a/src/server/pages/get.ts
+++ b/src/server/pages/get.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { JsonSchema } from "json-schema-to-zod";

--- a/src/server/pages/get.ts
+++ b/src/server/pages/get.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { JsonSchema } from "json-schema-to-zod";

--- a/src/server/pages/goto.ts
+++ b/src/server/pages/goto.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/goto.ts
+++ b/src/server/pages/goto.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/goto.ts
+++ b/src/server/pages/goto.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/goto.ts
+++ b/src/server/pages/goto.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/info.ts
+++ b/src/server/pages/info.ts
@@ -65,5 +65,5 @@ infoRouter.openapi(route, async (c) => {
     url: page.url(),
     title: await page.title(),
     progress: page.progress,
-  });
+  }, 200);
 });

--- a/src/server/pages/info.ts
+++ b/src/server/pages/info.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/info.ts
+++ b/src/server/pages/info.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/info.ts
+++ b/src/server/pages/info.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/info.ts
+++ b/src/server/pages/info.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";
@@ -60,10 +60,13 @@ infoRouter.openapi(route, async (c) => {
     return c.json({ message: "Page not found" }, 400);
   }
 
-  return c.json({
-    id: page.pageId,
-    url: page.url(),
-    title: await page.title(),
-    progress: page.progress,
-  }, 200);
+  return c.json(
+    {
+      id: page.pageId,
+      url: page.url(),
+      title: await page.title(),
+      progress: page.progress,
+    },
+    200,
+  );
 });

--- a/src/server/pages/list.ts
+++ b/src/server/pages/list.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/list.ts
+++ b/src/server/pages/list.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/list.ts
+++ b/src/server/pages/list.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/list.ts
+++ b/src/server/pages/list.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/list.ts
+++ b/src/server/pages/list.ts
@@ -62,5 +62,5 @@ ListRouter.openapi(route, async (c) => {
 
   console.log("PAGES", pages);
 
-  return c.json(pages);
+  return c.json(pages, 200);
 });

--- a/src/server/pages/newPage.ts
+++ b/src/server/pages/newPage.ts
@@ -43,5 +43,5 @@ newPageRouter.openapi(route, async (c) => {
 
   const page = await browser.newPage();
 
-  return c.json({ pageId: page.pageId });
+  return c.json({ pageId: page.pageId }, 200);
 });

--- a/src/server/pages/newPage.ts
+++ b/src/server/pages/newPage.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/newPage.ts
+++ b/src/server/pages/newPage.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/newPage.ts
+++ b/src/server/pages/newPage.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/newPage.ts
+++ b/src/server/pages/newPage.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 

--- a/src/server/pages/screenshot.ts
+++ b/src/server/pages/screenshot.ts
@@ -70,5 +70,5 @@ screenshotRouter.openapi(route, async (c) => {
     return c.json({ message: "Failed to take screenshot" }, 500);
   }
 
-  return c.json({ image });
+  return c.json({ image }, 200);
 });

--- a/src/server/pages/screenshot.ts
+++ b/src/server/pages/screenshot.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/screenshot.ts
+++ b/src/server/pages/screenshot.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/screenshot.ts
+++ b/src/server/pages/screenshot.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/screenshot.ts
+++ b/src/server/pages/screenshot.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { BROWSERS } from "../browser/launch";
 import { PageParamsSchema } from "../schemas";

--- a/src/server/pages/step.ts
+++ b/src/server/pages/step.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/step.ts
+++ b/src/server/pages/step.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/step.ts
+++ b/src/server/pages/step.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";
@@ -97,8 +97,8 @@ stepRouter.openapi(route, async (c) => {
   if (userOpts?.inventory) {
     inventory = new Inventory(
       Object.entries(userOpts.inventory).map(
-        ([name, value]) => ({ name, value } as InventoryValue)
-      )
+        ([name, value]) => ({ name, value }) as InventoryValue,
+      ),
     );
   }
 
@@ -109,8 +109,11 @@ stepRouter.openapi(route, async (c) => {
 
   const step = await page.step(command, responseSchema, opts);
 
-  return c.json({
-    result: step,
-    state: await page.state(command, page.progress),
-  }, 200);
+  return c.json(
+    {
+      result: step,
+      state: await page.state(command, page.progress),
+    },
+    200,
+  );
 });

--- a/src/server/pages/step.ts
+++ b/src/server/pages/step.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { z } from "zod";
+import { z } from "lib/zod"
 import { JsonSchema } from "json-schema-to-zod";
 
 import { BROWSERS } from "../browser/launch";

--- a/src/server/pages/step.ts
+++ b/src/server/pages/step.ts
@@ -112,5 +112,5 @@ stepRouter.openapi(route, async (c) => {
   return c.json({
     result: step,
     state: await page.state(command, page.progress),
-  });
+  }, 200);
 });

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const browseSchema = z.object({
   startUrl: z.string().url().openapi({ example: "https://google.com" }),

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const browseSchema = z.object({
   startUrl: z.string().url().openapi({ example: "https://google.com" }),

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const browseSchema = z.object({
   startUrl: z.string().url().openapi({ example: "https://google.com" }),
@@ -17,7 +17,7 @@ export const InventorySchema = z.array(
     type: z
       .union([z.literal("string"), z.literal("number")])
       .openapi({ example: "string" }),
-  })
+  }),
 );
 
 // types to handle arbitrary json output
@@ -26,7 +26,7 @@ type Literal = z.infer<typeof literalSchema>;
 type Json = Literal | { [key: string]: Json } | Json[];
 export const jsonSchema: z.ZodType<Json> = z
   .lazy(() =>
-    z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)])
+    z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]),
   )
   .openapi({
     example: {

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 
 export const browseSchema = z.object({
   startUrl: z.string().url().openapi({ example: "https://google.com" }),

--- a/src/server/schemas/agentSchemas.ts
+++ b/src/server/schemas/agentSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const AgentSchema = z.object({
   provider: z.string().default("openai").openapi({ example: "openai" }),

--- a/src/server/schemas/agentSchemas.ts
+++ b/src/server/schemas/agentSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export const AgentSchema = z.object({
   provider: z.string().default("openai").openapi({ example: "openai" }),

--- a/src/server/schemas/agentSchemas.ts
+++ b/src/server/schemas/agentSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const AgentSchema = z.object({
   provider: z.string().default("openai").openapi({ example: "openai" }),

--- a/src/server/schemas/agentSchemas.ts
+++ b/src/server/schemas/agentSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const AgentSchema = z.object({
   provider: z.string().default("openai").openapi({ example: "openai" }),

--- a/src/server/schemas/pageSchemas.ts
+++ b/src/server/schemas/pageSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const PageParamsSchema = z.object({
   browserSession: z.string(),

--- a/src/server/schemas/pageSchemas.ts
+++ b/src/server/schemas/pageSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const PageParamsSchema = z.object({
   browserSession: z.string(),

--- a/src/server/schemas/pageSchemas.ts
+++ b/src/server/schemas/pageSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const PageParamsSchema = z.object({
   browserSession: z.string(),

--- a/src/server/schemas/pageSchemas.ts
+++ b/src/server/schemas/pageSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export const PageParamsSchema = z.object({
   browserSession: z.string(),

--- a/src/types/agentBrowser.types.ts
+++ b/src/types/agentBrowser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const BrowserBehaviorConfig = z.object({
   goToDelay: z.number().int().default(1000),

--- a/src/types/agentBrowser.types.ts
+++ b/src/types/agentBrowser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const BrowserBehaviorConfig = z.object({
   goToDelay: z.number().int().default(1000),

--- a/src/types/agentBrowser.types.ts
+++ b/src/types/agentBrowser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 
 export const BrowserBehaviorConfig = z.object({
   goToDelay: z.number().int().default(1000),

--- a/src/types/agentBrowser.types.ts
+++ b/src/types/agentBrowser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const BrowserBehaviorConfig = z.object({
   goToDelay: z.number().int().default(1000),

--- a/src/types/browser/actionStep.types.ts
+++ b/src/types/browser/actionStep.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/actionStep.types.ts
+++ b/src/types/browser/actionStep.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/actionStep.types.ts
+++ b/src/types/browser/actionStep.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),
@@ -10,7 +10,7 @@ export const Type = z.object({
   index: z
     .number()
     .describe(
-      "The index of the elements in the aria tree. This should be an element that you can enter text such as textarea, combobox, textbox, or searchbox"
+      "The index of the elements in the aria tree. This should be an element that you can enter text such as textarea, combobox, textbox, or searchbox",
     ),
   text: z.string().describe("The text to enter"), // input text
 });
@@ -52,17 +52,17 @@ export type ActionStep = z.infer<typeof ActionStep>;
 export const ModelResponse = z.object({
   progressAssessment: z.string(),
   command: BrowserActionSchemaArray.optional().describe(
-    "List of browser actions"
+    "List of browser actions",
   ),
   objectiveComplete: ObjectiveComplete.optional().describe(
-    "Only return description of result if objective is complete"
+    "Only return description of result if objective is complete",
   ),
   description: z.string(),
 });
 
 export const ModelResponseSchema = <TObjectiveComplete extends z.AnyZodObject>(
   objectiveCompleteExtension?: TObjectiveComplete,
-  commandSchema: z.ZodSchema<any> = BrowserActionSchemaArray
+  commandSchema: z.ZodSchema<any> = BrowserActionSchemaArray,
 ) =>
   z.object({
     progressAssessment: z.string(),
@@ -71,40 +71,40 @@ export const ModelResponseSchema = <TObjectiveComplete extends z.AnyZodObject>(
       ? ObjectiveComplete.merge(objectiveCompleteExtension)
           .optional()
           .describe(
-            "Only return description of result if objective is complete"
+            "Only return description of result if objective is complete",
           )
       : ObjectiveComplete.optional().describe(
-          "Only return description of result if objective is complete"
+          "Only return description of result if objective is complete",
         ),
     description: z.string(),
   });
 
 export type ModelResponseType<
-  TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete
+  TObjectiveComplete extends z.AnyZodObject = typeof ObjectiveComplete,
 > = z.infer<ReturnType<typeof ModelResponseSchema<TObjectiveComplete>>>;
 
 export const ObjectiveCompleteResponse = <T extends z.AnyZodObject>(
-  extension?: T
+  extension?: T,
 ) =>
   z.object({
     progressAssessment: z.string(),
     objectiveComplete: extension
       ? extension.describe(
-          "Only return description of result if objective is complete"
+          "Only return description of result if objective is complete",
         )
       : ObjectiveComplete.describe(
-          "Only return description of result if objective is complete"
+          "Only return description of result if objective is complete",
         ),
     description: z.string(),
   });
 
 export type ObjectiveCompleteResponse<
-  TObjectiveComplete extends z.AnyZodObject
+  TObjectiveComplete extends z.AnyZodObject,
 > = z.infer<ReturnType<typeof ObjectiveCompleteResponse<TObjectiveComplete>>>;
 
 // Function to merge a ZodObject into objectiveComplete within ModelResponse with a default empty schema
 export const extendModelResponse = <T extends z.ZodObject<any>>(
-  additionalSchema: T = z.object({}) as T
+  additionalSchema: T = z.object({}) as T,
 ) => {
   const updatedObjectiveComplete = ObjectiveComplete.merge(additionalSchema)
     .optional()

--- a/src/types/browser/actionStep.types.ts
+++ b/src/types/browser/actionStep.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/actions.types.ts
+++ b/src/types/browser/actions.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/actions.types.ts
+++ b/src/types/browser/actions.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),
@@ -10,7 +10,7 @@ const Type = z.object({
   index: z
     .number()
     .describe(
-      "The index of the elements in the aria tree. This should be an element that you can enter text such as textarea, combobox, textbox, or searchbox"
+      "The index of the elements in the aria tree. This should be an element that you can enter text such as textarea, combobox, textbox, or searchbox",
     ),
   text: z.string().describe("The text to enter"), // input text
 });

--- a/src/types/browser/actions.types.ts
+++ b/src/types/browser/actions.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/actions.types.ts
+++ b/src/types/browser/actions.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 const Click = z.object({
   kind: z.literal("Click").describe("Click on an element"),

--- a/src/types/browser/browser.types.ts
+++ b/src/types/browser/browser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export enum BrowserMode {
   vision = "vision",

--- a/src/types/browser/browser.types.ts
+++ b/src/types/browser/browser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export enum BrowserMode {
   vision = "vision",

--- a/src/types/browser/browser.types.ts
+++ b/src/types/browser/browser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export enum BrowserMode {
   vision = "vision",

--- a/src/types/browser/browser.types.ts
+++ b/src/types/browser/browser.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export enum BrowserMode {
   vision = "vision",

--- a/src/types/browser/objectiveComplete.types.ts
+++ b/src/types/browser/objectiveComplete.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const ObjectiveComplete = z.object({
   kind: z.literal("ObjectiveComplete").describe("Objective is complete"),

--- a/src/types/browser/objectiveComplete.types.ts
+++ b/src/types/browser/objectiveComplete.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const ObjectiveComplete = z.object({
   kind: z.literal("ObjectiveComplete").describe("Objective is complete"),

--- a/src/types/browser/objectiveComplete.types.ts
+++ b/src/types/browser/objectiveComplete.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export const ObjectiveComplete = z.object({
   kind: z.literal("ObjectiveComplete").describe("Objective is complete"),

--- a/src/types/browser/objectiveComplete.types.ts
+++ b/src/types/browser/objectiveComplete.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const ObjectiveComplete = z.object({
   kind: z.literal("ObjectiveComplete").describe("Objective is complete"),

--- a/src/types/browser/objectiveState.types.ts
+++ b/src/types/browser/objectiveState.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const StateType = z.enum(["html", "text", "markdown", "image", "aria"]);
 export type StateType = z.infer<typeof StateType>;

--- a/src/types/browser/objectiveState.types.ts
+++ b/src/types/browser/objectiveState.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const StateType = z.enum(["html", "text", "markdown", "image", "aria"]);
 export type StateType = z.infer<typeof StateType>;

--- a/src/types/browser/objectiveState.types.ts
+++ b/src/types/browser/objectiveState.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const StateType = z.enum(["html", "text", "markdown", "image", "aria"]);
 export type StateType = z.infer<typeof StateType>;

--- a/src/types/browser/objectiveState.types.ts
+++ b/src/types/browser/objectiveState.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export const StateType = z.enum(["html", "text", "markdown", "image", "aria"]);
 export type StateType = z.infer<typeof StateType>;

--- a/src/types/collectiveMemory/config.types.ts
+++ b/src/types/collectiveMemory/config.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../../lib/zod";
 
 export const CollectiveMemoryConfig = z.object({
   endpoint: z

--- a/src/types/collectiveMemory/config.types.ts
+++ b/src/types/collectiveMemory/config.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 export const CollectiveMemoryConfig = z.object({
   endpoint: z

--- a/src/types/collectiveMemory/config.types.ts
+++ b/src/types/collectiveMemory/config.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 export const CollectiveMemoryConfig = z.object({
   endpoint: z

--- a/src/types/collectiveMemory/config.types.ts
+++ b/src/types/collectiveMemory/config.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 export const CollectiveMemoryConfig = z.object({
   endpoint: z

--- a/src/types/memory.types.ts
+++ b/src/types/memory.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { ModelResponseSchema } from "./browser/actionStep.types";
 import { ObjectiveState } from "./browser";

--- a/src/types/memory.types.ts
+++ b/src/types/memory.types.ts
@@ -1,4 +1,4 @@
-import { z } from "../lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { ModelResponseSchema } from "./browser/actionStep.types";
 import { ObjectiveState } from "./browser";

--- a/src/types/memory.types.ts
+++ b/src/types/memory.types.ts
@@ -1,4 +1,4 @@
-import { z } from "lib/zod";
+import { z } from "../lib/zod";
 
 import { ModelResponseSchema } from "./browser/actionStep.types";
 import { ObjectiveState } from "./browser";

--- a/src/types/memory.types.ts
+++ b/src/types/memory.types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { ModelResponseSchema } from "./browser/actionStep.types";
 import { ObjectiveState } from "./browser";

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,19 +3,18 @@ import os from "os";
 import path from "path";
 
 const loadConfigFile = (filePath: string): any => {
-    try {
-      return JSON.parse(fs.readFileSync(filePath, "utf8"));
-    } catch (error) {
-      return {};
-    }
-  };
-  
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    return {};
+  }
+};
+
 export const nolitarc = () => {
-    try {
-        const homeConfig = loadConfigFile(path.resolve(os.homedir(), ".nolitarc"));
-        return homeConfig;
-    }
-    catch {
-        return {};
-    }
-}
+  try {
+    const homeConfig = loadConfigFile(path.resolve(os.homedir(), ".nolitarc"));
+    return homeConfig;
+  } catch {
+    return {};
+  }
+};

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -24,7 +24,7 @@ export class Logger {
 
   constructor(
     logLevels?: string[],
-    callback?: (input: string) => any | undefined
+    callback?: (input: string) => any | undefined,
   ) {
     this.logStream = [];
     this.logLevels = logLevels || ["info"];

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -8,11 +8,11 @@ export function generateUUID() {
   const uuid = `${bytes.toString("hex", 0, 4)}-${bytes.toString(
     "hex",
     4,
-    6
+    6,
   )}-${bytes.toString("hex", 6, 8)}-${bytes.toString(
     "hex",
     8,
-    10
+    10,
   )}-${bytes.toString("hex", 10, 16)}`;
   return uuid;
 }

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -10,7 +10,7 @@ import {
   ObjectiveComplete,
 } from "../../src/types/browser/actionStep.types";
 
-import { z } from "../../src/lib/zod";
+import { z } from "@hono/zod-openapi";
 import { ObjectiveState } from "../../src/types/browser";
 import { completionApiBuilder } from "../../src/agent/config";
 

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -10,7 +10,7 @@ import {
   ObjectiveComplete,
 } from "../../src/types/browser/actionStep.types";
 
-import { z } from "zod";
+import { z } from "lib/zod"
 import { ObjectiveState } from "../../src/types/browser";
 import { completionApiBuilder } from "../../src/agent/config";
 

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -10,7 +10,7 @@ import {
   ObjectiveComplete,
 } from "../../src/types/browser/actionStep.types";
 
-import { z } from "lib/zod";
+import { z } from "../../src/lib/zod";
 import { ObjectiveState } from "../../src/types/browser";
 import { completionApiBuilder } from "../../src/agent/config";
 

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -10,7 +10,7 @@ import {
   ObjectiveComplete,
 } from "../../src/types/browser/actionStep.types";
 
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 import { ObjectiveState } from "../../src/types/browser";
 import { completionApiBuilder } from "../../src/agent/config";
 
@@ -34,7 +34,7 @@ describe("Agent -- configs", () => {
     const prompt = await agent.prompt(
       stateActionPair1.objectiveState,
       [stateActionPair1],
-      {}
+      {},
     );
     expect(prompt[0].role).toBe("user");
     expect(prompt[0].content).toContain("Here are examples of a request");
@@ -63,11 +63,11 @@ describe("Agent", () => {
     const prompt = await agent.prompt(
       stateActionPair1.objectiveState,
       [stateActionPair1],
-      {}
+      {},
     );
     expect(prompt[0].role).toBe("user");
     expect(prompt[0].content).toContain(
-      `{"objectiveState":{"kind":"ObjectiveState","objective":"how much is an gadget 11 pro","progress":[]`
+      `{"objectiveState":{"kind":"ObjectiveState","objective":"how much is an gadget 11 pro","progress":[]`,
     );
   });
 
@@ -75,12 +75,12 @@ describe("Agent", () => {
     const prompt = await agent.prompt(
       objectiveStateExample1,
       [stateActionPair1],
-      {}
+      {},
     );
 
     const response = await agent.call(
       prompt,
-      ModelResponseSchema(ObjectiveComplete)
+      ModelResponseSchema(ObjectiveComplete),
     );
     const res = ModelResponseSchema(ObjectiveComplete).parse(response);
     expect(res.command).toStrictEqual([
@@ -92,7 +92,7 @@ describe("Agent", () => {
     const prompt = await agent.prompt(
       objectiveStateExample1,
       [stateActionPair1],
-      {}
+      {},
     );
 
     const testSchema = ObjectiveComplete.extend({
@@ -114,11 +114,11 @@ describe("Agent", () => {
     const prompt = await agent.prompt(
       objectiveStateExample1,
       [stateActionPair1],
-      {}
+      {},
     );
     const response = await agent.askCommand(
       prompt,
-      ModelResponseSchema(ObjectiveComplete)
+      ModelResponseSchema(ObjectiveComplete),
     );
     expect(response!.command).toStrictEqual([
       { index: 5, kind: "Type", text: "gadget 11 pro price" },
@@ -152,7 +152,7 @@ describe("Agent", () => {
 
     const response = await agent.modifyActions(
       modifiedObjectiveStateExample1,
-      stateActionPair1
+      stateActionPair1,
     );
 
     expect(response?.command[0].index).toStrictEqual(20);
@@ -164,7 +164,7 @@ describe("Agent", () => {
     ]);
     const response = await agent.actionCall(
       prompt,
-      ModelResponseSchema(ObjectiveComplete)
+      ModelResponseSchema(ObjectiveComplete),
     );
 
     expect(response?.command[0].index).toStrictEqual(5);
@@ -179,7 +179,7 @@ describe("Agent", () => {
       prompt,
       ObjectiveComplete.extend({
         website: z.string().describe("The website name"),
-      })
+      }),
     );
 
     console.log("Response:", response);

--- a/tests/agent/messages.test.ts
+++ b/tests/agent/messages.test.ts
@@ -32,7 +32,7 @@ describe("CommandPrompt", () => {
     const messages = commandPrompt(stateActionPair1.objectiveState);
     expect(messages[0].role).toBe("user");
     expect(messages[0].content).toContain(
-      "Please generate the next ActionStep for"
+      "Please generate the next ActionStep for",
     );
 
     expect(messages.length).toBe(1);
@@ -47,12 +47,12 @@ describe("CommandPrompt", () => {
         inventory: new Inventory([
           { value: "test", name: "test", type: "string" },
         ]),
-      }
+      },
     );
 
     expect(messages[1].role).toBe("user");
     expect(messages[1].content).toContain(
-      "Please generate the next ActionStep for"
+      "Please generate the next ActionStep for",
     );
 
     expect(messages.length).toBe(2);
@@ -67,7 +67,7 @@ describe("CommandPrompt", () => {
 
     expect(messages[1].role).toBe("user");
     expect(messages[1].content).toContain(
-      "Please generate the next ActionStep for"
+      "Please generate the next ActionStep for",
     );
 
     expect(messages.length).toBe(2);
@@ -83,12 +83,12 @@ describe("CommandPrompt", () => {
 
     expect(messages[1].role).toBe("user");
     expect(messages[1].content).toContain(
-      "Here are examples of a previous request"
+      "Here are examples of a previous request",
     );
 
     expect(messages[2].role).toBe("user");
     expect(messages[2].content).toContain(
-      "Please generate the next ActionStep for"
+      "Please generate the next ActionStep for",
     );
 
     expect(messages.length).toBe(3);
@@ -101,7 +101,7 @@ describe("CommandPrompt", () => {
 
     expect(messages[1].role).toBe("user");
     expect(messages[1].content).toContain(
-      "Please generate the next ActionStep for"
+      "Please generate the next ActionStep for",
     );
 
     expect(messages.length).toBe(2);
@@ -117,7 +117,7 @@ describe("getPrompt", () => {
     const messages = getPrompt(stateActionPair1.objectiveState.ariaTree);
     expect(messages[0].role).toBe("user");
     expect(messages[0].content).toContain(
-      "Here is the current aria of the page"
+      "Here is the current aria of the page",
     );
 
     expect(messages.length).toBe(1);
@@ -130,7 +130,7 @@ describe("getPrompt", () => {
 
     expect(messages[0].role).toBe("user");
     expect(messages[0].content).toContain(
-      "Here is the current aria of the page"
+      "Here is the current aria of the page",
     );
 
     expect(messages.length).toBe(1);
@@ -145,7 +145,7 @@ describe("getPrompt", () => {
 
     expect(messages[1].role).toBe("user");
     expect(messages[1].content).toContain(
-      "Here is the current aria of the page"
+      "Here is the current aria of the page",
     );
 
     expect(messages.length).toBe(2);
@@ -161,12 +161,12 @@ describe("getPrompt", () => {
 
     expect(messages[1].role).toBe("user");
     expect(messages[1].content).toContain(
-      "Here are examples of a previous request"
+      "Here are examples of a previous request",
     );
 
     expect(messages[2].role).toBe("user");
     expect(messages[2].content).toContain(
-      "Please generate the next ActionStep for"
+      "Please generate the next ActionStep for",
     );
 
     expect(messages.length).toBe(3);
@@ -179,7 +179,7 @@ describe("getPrompt", () => {
 
     expect(messages[0].role).toBe("user");
     expect(messages[0].content).toContain(
-      "Here is the current aria of the page"
+      "Here is the current aria of the page",
     );
 
     expect(messages.length).toBe(1);

--- a/tests/browser/browserUtils.test.ts
+++ b/tests/browser/browserUtils.test.ts
@@ -7,7 +7,7 @@ describe("chromePaths", () => {
 
     if (!(process.env.CI === "true")) {
       expect(chromePath).toBe(
-        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       );
       expect(chromePath).toBeDefined();
       expect(chromePath!.toLocaleLowerCase()).toContain("chrome");

--- a/tests/browser/page/browse.test.ts
+++ b/tests/browser/page/browse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "../../../src/lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { Browser } from "../../../src/browser";
 

--- a/tests/browser/page/browse.test.ts
+++ b/tests/browser/page/browse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { Browser } from "../../../src/browser";
 

--- a/tests/browser/page/browse.test.ts
+++ b/tests/browser/page/browse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "lib/zod";
+import { z } from "../../../src/lib/zod";
 
 import { Browser } from "../../../src/browser";
 

--- a/tests/browser/page/browse.test.ts
+++ b/tests/browser/page/browse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { Browser } from "../../../src/browser";
 
@@ -39,7 +39,7 @@ describe("Page", () => {
             .describe("The email addresses found on the page"),
         }),
         maxTurns: 5,
-      }
+      },
     );
     expect(result).toBeDefined();
     await browser.close();

--- a/tests/browser/page/click.test.ts
+++ b/tests/browser/page/click.test.ts
@@ -54,7 +54,7 @@ describe("Page interaction -- TYPE", () => {
     await page.goto(dataUrl);
 
     let resultText = await page.page.evaluate(
-      () => document.getElementById("result")!.textContent
+      () => document.getElementById("result")!.textContent,
     );
     expect(resultText).toEqual("");
 
@@ -66,7 +66,7 @@ describe("Page interaction -- TYPE", () => {
 
     // Verify the updated state of the result paragraph after the click
     resultText = await page.page.evaluate(
-      () => document.getElementById("result")!.textContent
+      () => document.getElementById("result")!.textContent,
     );
     expect(resultText).toBe("Button clicked!");
     await browser.close();
@@ -79,7 +79,7 @@ describe("Page interaction -- TYPE", () => {
     await page.goto(dataUrl);
 
     let resultText = await page.page.evaluate(
-      () => document.getElementById("result")!.textContent
+      () => document.getElementById("result")!.textContent,
     );
     expect(resultText).toEqual("");
 
@@ -93,7 +93,7 @@ describe("Page interaction -- TYPE", () => {
 
     // Verify the updated state of the result paragraph after the click
     resultText = await page.page.evaluate(
-      () => document.getElementById("result")!.textContent
+      () => document.getElementById("result")!.textContent,
     );
     expect(resultText).toBe("Button clicked!");
     await browser.close();
@@ -105,7 +105,7 @@ describe("Page interaction -- TYPE", () => {
 
     await page.goto(dataUrl);
     let resultText = await page.page.evaluate(
-      () => document.getElementById("result")!.textContent
+      () => document.getElementById("result")!.textContent,
     );
     expect(resultText).toEqual("");
 
@@ -114,7 +114,7 @@ describe("Page interaction -- TYPE", () => {
     // Verify the updated state of the result paragraph after the command
 
     resultText = await page.page.evaluate(
-      () => document.getElementById("result")!.textContent
+      () => document.getElementById("result")!.textContent,
     );
     expect(resultText).toBe("Button clicked!");
     await browser.close();

--- a/tests/browser/page/get.test.ts
+++ b/tests/browser/page/get.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { Browser } from "../../../src/browser";
 import { ObjectiveComplete } from "../../../src/types/browser";

--- a/tests/browser/page/get.test.ts
+++ b/tests/browser/page/get.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "../../../src/lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { Browser } from "../../../src/browser";
 import { ObjectiveComplete } from "../../../src/types/browser";

--- a/tests/browser/page/get.test.ts
+++ b/tests/browser/page/get.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "lib/zod";
+import { z } from "../../../src/lib/zod";
 
 import { Browser } from "../../../src/browser";
 import { ObjectiveComplete } from "../../../src/types/browser";

--- a/tests/browser/page/get.test.ts
+++ b/tests/browser/page/get.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { Browser } from "../../../src/browser";
 import { ObjectiveComplete } from "../../../src/types/browser";
@@ -38,7 +38,7 @@ describe("Page -- get", () => {
           .array(z.string())
           .describe("The email addresses found on the page"),
       }),
-      { agent }
+      { agent },
     );
     expect(result).toBeDefined();
     expect(result.email).toContain("tynan.daly@hdr.is");
@@ -59,7 +59,7 @@ describe("Page -- get", () => {
           .array(z.string())
           .describe("The email addresses found on the page"),
       }),
-      { agent }
+      { agent },
     );
 
     expect(result).toBeDefined();
@@ -76,7 +76,7 @@ describe("Page -- get", () => {
 
     const result = await page.get(
       "Find all the email addresses on the page",
-      ObjectiveComplete
+      ObjectiveComplete,
     );
 
     expect(result).toBeDefined();

--- a/tests/browser/page/page.test.ts
+++ b/tests/browser/page/page.test.ts
@@ -63,7 +63,7 @@ describe("Page", () => {
     const expectedStringPartial = "iVBOR";
     const screenshotB64 = screenshot.toString("base64");
     expect(screenshotB64.slice(0, expectedStringPartial.length)).toBe(
-      expectedStringPartial
+      expectedStringPartial,
     );
     await browser.close();
   });

--- a/tests/browser/page/step.test.ts
+++ b/tests/browser/page/step.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "../../../src/lib/zod";
+import { z } from "@hono/zod-openapi";
 
 import { Browser } from "../../../src/browser";
 

--- a/tests/browser/page/step.test.ts
+++ b/tests/browser/page/step.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "zod";
+import { z } from "lib/zod"
 
 import { Browser } from "../../../src/browser";
 

--- a/tests/browser/page/step.test.ts
+++ b/tests/browser/page/step.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "lib/zod";
+import { z } from "../../../src/lib/zod";
 
 import { Browser } from "../../../src/browser";
 

--- a/tests/browser/page/step.test.ts
+++ b/tests/browser/page/step.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "@jest/globals";
-import { z } from "lib/zod"
+import { z } from "lib/zod";
 
 import { Browser } from "../../../src/browser";
 
@@ -38,7 +38,7 @@ describe("Page", () => {
 
     const result = await page.step(
       "tell me the email addresses on the page",
-      schema
+      schema,
     );
 
     expect(result.objectiveComplete?.emails).toBeDefined();

--- a/tests/browser/page/type.test.ts
+++ b/tests/browser/page/type.test.ts
@@ -39,7 +39,7 @@ describe("Page interaction -- Type", () => {
     await page.goto(dataUrl);
 
     const initialValue = await page.page.evaluate(() =>
-      document.querySelector("textarea")!.value.trim()
+      document.querySelector("textarea")!.value.trim(),
     );
     expect(initialValue).toEqual("Hello, World!");
 
@@ -50,7 +50,7 @@ describe("Page interaction -- Type", () => {
       text: "High Dimensional Research",
     });
     const value = await page.page.evaluate(() =>
-      document.querySelector("textarea")!.value.trim()
+      document.querySelector("textarea")!.value.trim(),
     );
 
     expect(value).toEqual("High Dimensional Research");
@@ -63,7 +63,7 @@ describe("Page interaction -- Type", () => {
     await page.goto(dataUrl);
 
     const initialValue = await page.page.evaluate(() =>
-      document.querySelector("textarea")!.value.trim()
+      document.querySelector("textarea")!.value.trim(),
     );
     expect(initialValue).toEqual("Hello, World!");
 
@@ -76,7 +76,7 @@ describe("Page interaction -- Type", () => {
       },
     ]);
     const value = await page.page.evaluate(() =>
-      document.querySelector("textarea")!.value.trim()
+      document.querySelector("textarea")!.value.trim(),
     );
 
     expect(value).toEqual("High Dimensional Research");
@@ -93,10 +93,10 @@ describe("Page interaction -- Type", () => {
       "type `High Dimensional Research` into the text box. Please make sure to capitalize the type in the command array",
       {
         agent,
-      }
+      },
     );
     const value = await page.page.evaluate(() =>
-      document.querySelector("textarea")!.value.trim()
+      document.querySelector("textarea")!.value.trim(),
     );
 
     expect(value).toEqual("High Dimensional Research");

--- a/tests/collectiveMemory/compareAriaTrees.test.ts
+++ b/tests/collectiveMemory/compareAriaTrees.test.ts
@@ -66,7 +66,7 @@ describe("updateCommandIndices", () => {
     const res = updateCommandIndices(
       objectiveStateOld,
       objectiveStateNew,
-      commands
+      commands,
     );
 
     expect(res).toStrictEqual(expectedCommands);

--- a/tests/collectiveMemory/findRoute.test.ts
+++ b/tests/collectiveMemory/findRoute.test.ts
@@ -12,7 +12,7 @@ describe("Fetch Route", () => {
       {
         apiKey: process.env.HDR_API_KEY!,
         endpoint: process.env.HDR_ENDPOINT!,
-      }
+      },
     );
     expect(res.length).toBeGreaterThan(0);
   });
@@ -29,7 +29,7 @@ describe("Find Route", () => {
       {
         apiKey: process.env.HDR_API_KEY!,
         endpoint: process.env.HDR_ENDPOINT!,
-      }
+      },
     );
     expect(res!.length).toBeGreaterThan(0);
   });

--- a/tests/collectiveMemory/memorize.test.ts
+++ b/tests/collectiveMemory/memorize.test.ts
@@ -35,7 +35,7 @@ describe("Memorize", () => {
       objectiveStateExample1,
       actionStepExample1,
       generateUUID(),
-      cmConfig
+      cmConfig,
     );
 
     expect(memory).toBe(true);
@@ -49,7 +49,7 @@ describe("Memorize", () => {
       objectiveStateExample1,
       actionStepExample1,
       generateUUID(),
-      cmConfig
+      cmConfig,
     );
 
     expect(memory).toBe(true);

--- a/tests/collectiveMemory/remember.test.ts
+++ b/tests/collectiveMemory/remember.test.ts
@@ -17,7 +17,7 @@ describe("Remember", () => {
       {
         apiKey: process.env.HDR_API_KEY!,
         endpoint: process.env.HDR_ENDPOINT!,
-      }
+      },
     );
 
     const memory = memories[0].actionStep.command![0];
@@ -31,7 +31,7 @@ describe("Remember", () => {
       {
         apiKey: process.env.HDR_API_KEY!,
         endpoint: process.env.HDR_ENDPOINT!,
-      }
+      },
     );
 
     const memory = memories[0].actionStep.command![0];
@@ -48,7 +48,7 @@ describe("Fetch state actions pairs", () => {
       {
         apiKey: process.env.HDR_API_KEY!,
         endpoint: process.env.HDR_ENDPOINT!,
-      }
+      },
     );
     expect(stateActionPairs.length).toBe(2);
   });
@@ -61,7 +61,7 @@ describe("Fetch state actions sequences", () => {
       {
         apiKey: process.env.HDR_API_KEY!,
         endpoint: "https://api.hdr.is",
-      }
+      },
     );
     expect(stateActionPairs.length).toBe(5);
   });

--- a/tests/server/pages/content.test.ts
+++ b/tests/server/pages/content.test.ts
@@ -35,7 +35,7 @@ describe("pageApi -- content", () => {
       .expect(async (res) => {
         expect(res.body.type).toBe("html");
         expect(res.body.pageContent).toContain(
-          '<a href="https://www.iana.org/domains/example">More information...</a>'
+          '<a href="https://www.iana.org/domains/example">More information...</a>',
         );
       });
   });
@@ -47,7 +47,7 @@ describe("pageApi -- content", () => {
       .expect(async (res) => {
         expect(res.body.type).toBe("markdown");
         expect(res.body.pageContent).toContain(
-          "[More information...](https://www.iana.org/domains/example)"
+          "[More information...](https://www.iana.org/domains/example)",
         );
       });
   });
@@ -59,7 +59,7 @@ describe("pageApi -- content", () => {
       .expect(async (res) => {
         expect(res.body.type).toBe("text");
         expect(res.body.pageContent).toContain(
-          "This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission."
+          "This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.",
         );
       });
   });

--- a/tests/server/pages/newPage.test.ts
+++ b/tests/server/pages/newPage.test.ts
@@ -41,7 +41,7 @@ describe("pageApi -- newPage", () => {
       .expect((res) => {
         expect(res.body.pageId).toBeDefined();
         expect(
-          BROWSERS.get(sessionId)?.pages.get(res.body.pageId)
+          BROWSERS.get(sessionId)?.pages.get(res.body.pageId),
         ).toBeDefined();
       });
   });

--- a/tests/server/pages/step.test.ts
+++ b/tests/server/pages/step.test.ts
@@ -39,7 +39,7 @@ describe("pageApi -- step", () => {
       .expect(200)
       .expect((res) => {
         expect(res.body.state.url).toBe(
-          "https://www.iana.org/help/example-domains"
+          "https://www.iana.org/help/example-domains",
         );
       });
   }, 20000);

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -4,6 +4,6 @@ import { generateUUID } from "../../src/utils/uuid";
 test("generateUUID", () => {
   const uuid = generateUUID();
   expect(uuid).toMatch(
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
   );
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
     "compilerOptions": {
       "target": "ESNext",                    // Set the JavaScript version for emitted JavaScript and include compatible lib types
       "module": "CommonJS",                  // Use CommonJS module system, as used by Node.js
+      "baseUrl": "./src",
+      "rootDir": "./src",
       "declaration": true,
       "declarationDir": "./dist/types",      // Output directory for type definitions         
       "declarationMap": true,


### PR DESCRIPTION
- updates `@hono/zod-openapi` to 0.15.0
- uses `extendZodWithOpenApi` on regular old zod in a library file. If we see further weird phenomenon we need to look more at the `zod` that gets shipped with `zod-openapi` because it's not [intended for use as sole middleware](https://github.com/honojs/middleware/tree/main/packages/zod-openapi#combining-with-hono)
- amends all our server responses to always give a status code

Tested by pushing `nolita@experimental` tag and running in a Docker container running node 20 and no other dependencies. I think this is safe to hit dev for further testing of functionality.