### PR TITLE
various: glue for 2.2.0

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Creating a new project](./create.md)
 
 # Using Nolita
+- [Using local models (experimental)](./use/local.md)
 - [Use Nolita as a scraper](./use/scrape.md)
 
 # Nolita projects

--- a/docs/src/use/local.md
+++ b/docs/src/use/local.md
@@ -6,6 +6,8 @@ Nolita can take both `local` and `ollama` providers for autonomous tasks. Howeve
 
 Ollama is supported as a provider and will connect to the default Ollama port when used. When you set `ollama` as a provider, the `model` name you provide to one that Ollama recognizes. For more information on available models for Ollama, see [its documentation](https://ollama.com/library).
 
+This means that we expect Ollama to be running when using Nolita with `ollama` as provider. You'll want to run Ollama's GUI or just `ollama serve` in a terminal window.
+
 ## Using local model files
 
 We use `node-llama-cpp` under the hood to run a model file. For information on `node-llama-cpp` and getting a model file for use, see [its documentation](https://withcatai.github.io/node-llama-cpp/guide/#getting-a-model-file).

--- a/docs/src/use/local.md
+++ b/docs/src/use/local.md
@@ -1,0 +1,21 @@
+# Using local models
+
+Nolita can take both `local` and `ollama` providers for autonomous tasks. However, at present functionality is quite limited; we mark usage of local models as experimental, but available. We encourage you to experiment with your own workflows and see where delegating to local models makes sense.
+
+## Using Ollama
+
+Ollama is supported as a provider and will connect to the default Ollama port when used. When you set `ollama` as a provider, the `model` name you provide to one that Ollama recognizes. For more information on available models for Ollama, see [its documentation](https://ollama.com/library).
+
+## Using local model files
+
+We use `node-llama-cpp` under the hood to run a model file. For information on `node-llama-cpp` and getting a model file for use, see [its documentation](https://withcatai.github.io/node-llama-cpp/guide/#getting-a-model-file).
+
+Once a model file is downloaded, Nolita accepts the **full path to the file** as a model name when using a `local` provider.
+
+You can set this, as usual, using `npx nolita auth`.
+
+## Usage and limitations
+
+Smaller models (7B and below) are far less capable of holding enough context to navigate the web alone. They can, however, still process data well. In our current usage, we find that [`page.get()`](/reference/classes/Page.html#get) calls function consistently. Other calls, like autonomous browsing and navigation, can stumble on navigating the Nolita state machine. It is not uncommon to see errors about `incorrect JSON` from our generators.
+
+You may, however, find better results with bigger local models; what models you can experiment with is a limitation of hardware.

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -297,7 +297,6 @@ export class Agent {
 export function makeAgent(
   prodiverOpts?: { provider: string; apiKey: string },
   modelConfig?: Partial<ModelConfig>,
-  customProvider?: { path: string },
   opts?: { systemPrompt?: string }
 ) {
   if (!prodiverOpts) {
@@ -318,7 +317,6 @@ export function makeAgent(
     provider: prodiverOpts.provider as Providers,
     apiKey: prodiverOpts.apiKey,
     model: modelConfig.model,
-    path: customProvider?.path,
   };
   return new Agent({
     providerConfig,

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -16,7 +16,6 @@ export type ProviderConfig = {
   provider: Providers;
   apiKey: string;
   model: string;
-  path?: string;
 };
 
 export type AgentConfig = {

--- a/src/agent/generators/generateObject.ts
+++ b/src/agent/generators/generateObject.ts
@@ -40,10 +40,7 @@ export async function generateObject<T extends z.ZodSchema<any>>(
       response = await generateObjectOllama(config.model, messages, options);
       break;
     case "local":
-      if (!config.path) {
-        throw new Error("Local provider requires a path to the model");
-      }
-      response = await generateObjectLocal(config.path, messages, options);
+      response = await generateObjectLocal(config.model, messages, options);
       break;
     case "openai":
     case "anthropic":

--- a/src/agent/generators/generateObjectLocal.ts
+++ b/src/agent/generators/generateObjectLocal.ts
@@ -35,7 +35,7 @@ export async function generateObjectLocal<T extends z.ZodSchema<any>>(
   const schema = zodToJsonSchema(options.schema);
   const grammar = new LlamaJsonSchemaGrammar(schema) as any;
 
-  const context = new LlamaContext({ model });
+  const context = new LlamaContext({ model, contextSize: 32168, batchSize: 32168 });
   const session = new LlamaChatSession({ context });
 
   const messagesString = messages

--- a/src/bin/commands/auth.ts
+++ b/src/bin/commands/auth.ts
@@ -44,8 +44,26 @@ const handleModelConfig = async (homeConfig: any) => {
         }, {
           name: 'Anthropic',
           value: 'anthropic',
+        },
+        {
+          name: 'Ollama',
+          value: 'ollama',
+        }, {
+          name: 'local',
+          value: 'local',
         }],
       });
+      if (provider === 'local' || provider === 'ollama') {
+        console.log('Using local models is experimental. Please see https://docs.nolita.ai/use/local.html for more information.');
+        const model = await input({
+          message: provider === 'ollama' ? 'Please enter your preferredmodel for Ollama.' : 'Please enter a full path to your model file.',
+          default: provider === 'ollama' ? 'llama3.1' : '/Users/yourname/model.gguf',
+        });
+        writeToNolitarc('agentProvider', provider);
+        writeToNolitarc('agentApiKey', '');
+        writeToNolitarc('agentModel', model);
+        return;
+      }
       const apiKey = await input({
         message: 'Please enter your provider API key.',
       });
@@ -78,7 +96,7 @@ const handleHDRApiKey = async (homeConfig: any) => {
   if (!hdrApiKey) {
     console.error('No HDR API key found in ~/.nolitarc.');
     const create = await confirm({
-      message: 'Would you like to sign up at dashboard.hdr.is?',
+      message: 'Would you like to open dashboard.hdr.is?',
     });
 
     if (create) {
@@ -87,7 +105,7 @@ const handleHDRApiKey = async (homeConfig: any) => {
 
     const apiKey = await input({
       message:
-        'Please access https://dashboard.hdr.is/keys and enter your generated HDR API key.',
+        'Please access https://dashboard.hdr.is/keys and enter your generated HDR API key, or press enter to skip.',
     });
     writeToNolitarc('hdrApiKey', apiKey);
   } else {

--- a/src/bin/commands/serve.ts
+++ b/src/bin/commands/serve.ts
@@ -14,21 +14,21 @@ export const builder = (yargs: Argv) => {
 };
 
 export const handler = async (argv: any) => {
-  const { port } = argv;
+  const { port = 3000 } = argv;
   console.log('Starting the server...');
   const app = setupServer();
-  serve({
+  const server = serve({
     fetch: app.fetch,
     port: port,
   });
   console.log(`Server started on port ${port}`);
-  console.log(`Documentation available at http://localhost:${port}/`);
+  console.log(`Documentation available at http://localhost:${port}/doc`);
   console.log('Press Ctrl+C to stop the server.');
 
   return new Promise<void>((resolve) => {
     const shutdown = () => {
       console.error(' Shutting down server...');
-      // Perform any necessary cleanup here
+      server.close();
       resolve();
     };
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -12,5 +12,8 @@ yargs(hideBin(process.argv))
   .command('auth', 'Authenticate and configure Nolita', {}, authRun)
   .command(createCommand)
   .command(serveCommand)
-  .help()
+  .help('help', '', false)
+  .fail(() => {
+    process.exit(1);
+  })
   .argv;

--- a/src/bin/run.ts
+++ b/src/bin/run.ts
@@ -52,7 +52,7 @@ const isValidUrl = (value: string): void => {
 };
 
 const isValidProvider = (value: string): void => {
-  if (value !== "openai" && value !== "anthropic") {
+  if (value !== "openai" && value !== "anthropic" && value !== "ollama" && value !== "local") {
     throw new Error("Invalid provider.");
   }
 };

--- a/src/bin/run.ts
+++ b/src/bin/run.ts
@@ -57,12 +57,6 @@ const isValidProvider = (value: string): void => {
   }
 };
 
-const isValidApiKey = (value: string, key: string): void => {
-  if (value.length === 0) {
-    throw new Error(`${key} not provided.`);
-  }
-};
-
 const isValidHdrApiKey = (value: string): void => {
   if (typeof value !== "string") {
     return;
@@ -90,7 +84,6 @@ const validate = (config: any): void => {
         return;
       case "agentApiKey":
         isValidString(value, key);
-        isValidApiKey(value as string, key);
         return;
       case "agentProvider":
         isValidString(value, key);
@@ -119,7 +112,7 @@ const getConfig = (
   agentModel:
     argv.agentModel || mergedConfig.agentModel || process.env.HDR_AGENT_MODEL,
   agentApiKey:
-    argv.agentApiKey || mergedConfig.agentApiKey || process.env.HDR_AGENT_API_KEY,
+    (argv.agentApiKey || mergedConfig.agentApiKey) ?? process.env.HDR_AGENT_API_KEY,
   hdrApiKey: argv.hdrApiKey || mergedConfig.hdrApiKey || process.env.HDR_API_KEY,
   headless: argv.headless ?? mergedConfig.headless ?? process.env.HDR_HEADLESS,
   hdrDisable: argv.hdrDisable ?? mergedConfig.hdrDisable ?? process.env.HDR_DISABLE,
@@ -131,7 +124,6 @@ const getConfig = (
 export const run = async (argv: any) => {
   const mergedConfig = loadConfigs(argv.config);
   const resolvedConfig = getConfig(mergedConfig, argv);
-
   // default true
   resolvedConfig.headless =
     resolvedConfig.headless !== undefined

--- a/src/nolita.ts
+++ b/src/nolita.ts
@@ -50,8 +50,7 @@ export class Nolita {
         apiKey: providerApiKey ?? process.env.OPENAI_API_KEY,
       },
       { model: opts?.model ?? "gpt-4", ...opts },
-      undefined,
-      { systemPrompt: opts?.systemPrompt }
+      { systemPrompt: opts?.systemPrompt },
     );
   }
 

--- a/tests/agent/generators/generateObject.test.ts
+++ b/tests/agent/generators/generateObject.test.ts
@@ -31,9 +31,8 @@ describe("generateObjectLocal", () => {
     const messages = getPrompt(ariaTreeExample);
     const providerConfig: ProviderConfig = {
       provider: "local",
-      model: "null",
+      model: "/Users/tynandaly/basin/hdr/browser/capybarahermes-2.5-mistral-7b.Q2_K.gguf",
       apiKey: "null",
-      path: "/Users/tynandaly/basin/hdr/browser/capybarahermes-2.5-mistral-7b.Q2_K.gguf",
     };
 
     const res = await generateObject(providerConfig, messages, {


### PR DESCRIPTION
- Add `local` and `ollama` to the auth command
- Removing `customProvider` and `config.path` in favour of just using pre-existing `model` in our providerConfig and reducing prop passing
- At some point Nolita.ts's `makeAgent` thinks we have too many args, so moved them around to make sense
- serve command doesn't clean up properly (something I fixed in a messy commit in #123), migrated that here
- We no longer see if the API key is longer than 0 chars. If it's a string, we're happy, and we do a `??` check now to not make an empty string `undefined`.
- yargs likes to show you the help command when you bail. This makes the terminal look like a mess with local models. It now doesn't do that.
- contextSize and batchSize need to be set for local models to work at all, so we set them
- adding documentation for local models — and `npx nolita auth` informs users of the article, too, so they understand limitations